### PR TITLE
fix: resolve admin page crash caused by concurrent DbContext operations

### DIFF
--- a/WhiskeyTracker.Web/Pages/Admin/Index.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Admin/Index.cshtml.cs
@@ -21,18 +21,10 @@ public class IndexModel : PageModel
 
     public async Task OnGetAsync()
     {
-        var usersTask = _context.Users.CountAsync();
-        var whiskiesTask = _context.Whiskies.CountAsync();
-        var bottlesTask = _context.Bottles.CountAsync();
-        var collectionsTask = _context.Collections.CountAsync();
-        var notesTask = _context.TastingNotes.CountAsync();
-
-        await Task.WhenAll(usersTask, whiskiesTask, bottlesTask, collectionsTask, notesTask);
-
-        TotalUsers = usersTask.Result;
-        TotalWhiskies = whiskiesTask.Result;
-        TotalBottles = bottlesTask.Result;
-        TotalCollections = collectionsTask.Result;
-        TotalTastingNotes = notesTask.Result;
+        TotalUsers = await _context.Users.CountAsync();
+        TotalWhiskies = await _context.Whiskies.CountAsync();
+        TotalBottles = await _context.Bottles.CountAsync();
+        TotalCollections = await _context.Collections.CountAsync();
+        TotalTastingNotes = await _context.TastingNotes.CountAsync();
     }
 }

--- a/WhiskeyTracker.Web/Pages/Error.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Error.cshtml.cs
@@ -6,6 +6,7 @@ namespace WhiskeyTracker.Web.Pages;
 
 [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
 [IgnoreAntiforgeryToken]
+[Microsoft.AspNetCore.Authorization.AllowAnonymous]
 public class ErrorModel : PageModel
 {
     public string? RequestId { get; set; }


### PR DESCRIPTION
## Summary
- Fixes #73
- The Admin index page was calling `CountAsync()` on 5 queries simultaneously via `Task.WhenAll()` using a single `DbContext` instance. EF Core prohibits concurrent operations on the same context and throws `InvalidOperationException` against a real database.
- The bug was invisible in development because the In-Memory EF Core provider runs synchronously — all queries "complete" before the next line executes. Against PostgreSQL in production, the queries are truly async and race each other, causing the crash every time.
- Also adds `[AllowAnonymous]` to `Error.cshtml.cs`, which was missing despite `AuthorizeFolder("/")` requiring auth for all pages — without it, unauthenticated exceptions would redirect to login instead of showing the error page.

## Test plan
- [x] `dotnet test` passes (45/45)
- [ ] Deploy to production and verify `/Admin` loads without error
- [ ] Verify the Admin nav link and all sub-pages (Users, Bottles, Collections, Maintenance) load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)