### PR TITLE
feat: add quick pour tracking for single drams

### DIFF
--- a/WhiskeyTracker.Tests/PourTests.cs
+++ b/WhiskeyTracker.Tests/PourTests.cs
@@ -1,7 +1,10 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.EntityFrameworkCore;
+using Moq;
 using WhiskeyTracker.Web.Data;
 using WhiskeyTracker.Web.Pages.Whiskies;
 using Xunit;
@@ -169,5 +172,141 @@ public class PourTests
         Assert.NotNull(dbSource);
         Assert.Equal(0, dbSource.CurrentVolumeMl);
         Assert.Equal(BottleStatus.Empty, dbSource.Status);
+    }
+}
+
+public class QuickPourTests
+{
+    private AppDbContext GetInMemoryContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private void SetMockUser(PageModel page, string userId)
+    {
+        var claims = new List<System.Security.Claims.Claim>
+        {
+            new System.Security.Claims.Claim(System.Security.Claims.ClaimTypes.NameIdentifier, userId)
+        };
+        var identity = new System.Security.Claims.ClaimsIdentity(claims, "TestAuthType");
+        var claimsPrincipal = new System.Security.Claims.ClaimsPrincipal(identity);
+        page.PageContext = new PageContext
+        {
+            HttpContext = new DefaultHttpContext { User = claimsPrincipal }
+        };
+        page.TempData = new Mock<ITempDataDictionary>().Object;
+    }
+
+    private async Task<(Bottle bottle, Whiskey whiskey)> SeedBottle(AppDbContext context,
+        int volumeMl = 750, BottleStatus status = BottleStatus.Opened)
+    {
+        var whiskey = new Whiskey { Name = "Test Whiskey", Distillery = "Test Distillery" };
+        context.Whiskies.Add(whiskey);
+        await context.SaveChangesAsync();
+
+        var collection = new Collection { Name = "Test Bar" };
+        context.Collections.Add(collection);
+        await context.SaveChangesAsync();
+
+        context.CollectionMembers.Add(new CollectionMember
+        {
+            CollectionId = collection.Id, UserId = "test-user", Role = CollectionRole.Owner
+        });
+
+        var bottle = new Bottle
+        {
+            WhiskeyId = whiskey.Id,
+            CollectionId = collection.Id,
+            CapacityMl = 750,
+            CurrentVolumeMl = volumeMl,
+            Status = status
+        };
+        context.Bottles.Add(bottle);
+        await context.SaveChangesAsync();
+
+        return (bottle, whiskey);
+    }
+
+    [Fact]
+    public async Task OnPost_DeductsVolume_AndRedirects()
+    {
+        using var context = GetInMemoryContext();
+        var (bottle, whiskey) = await SeedBottle(context, volumeMl: 750, status: BottleStatus.Opened);
+
+        var page = new QuickPourModel(context) { PourAmountOz = 2.0 };
+        SetMockUser(page, "test-user");
+
+        var result = await page.OnPostAsync(bottle.Id);
+
+        var redirect = Assert.IsType<RedirectToPageResult>(result);
+        Assert.Equal("./Details", redirect.PageName);
+
+        var db = await context.Bottles.AsNoTracking().FirstAsync(b => b.Id == bottle.Id);
+        // 2 oz * 29.5735 = 59ml rounded
+        Assert.Equal(750 - 59, db.CurrentVolumeMl);
+        Assert.Equal(BottleStatus.Opened, db.Status);
+    }
+
+    [Fact]
+    public async Task OnPost_OpensFull_BottleOnFirstPour()
+    {
+        using var context = GetInMemoryContext();
+        var (bottle, _) = await SeedBottle(context, volumeMl: 750, status: BottleStatus.Full);
+
+        var page = new QuickPourModel(context) { PourAmountOz = 1.5 };
+        SetMockUser(page, "test-user");
+
+        await page.OnPostAsync(bottle.Id);
+
+        var db = await context.Bottles.AsNoTracking().FirstAsync(b => b.Id == bottle.Id);
+        Assert.Equal(BottleStatus.Opened, db.Status);
+    }
+
+    [Fact]
+    public async Task OnPost_MarksBottleEmpty_WhenVolumeReachesZero()
+    {
+        using var context = GetInMemoryContext();
+        var (bottle, _) = await SeedBottle(context, volumeMl: 30, status: BottleStatus.Opened);
+
+        var page = new QuickPourModel(context) { PourAmountOz = 2.0 }; // 59ml > 30ml remaining
+        SetMockUser(page, "test-user");
+
+        await page.OnPostAsync(bottle.Id);
+
+        var db = await context.Bottles.AsNoTracking().FirstAsync(b => b.Id == bottle.Id);
+        Assert.Equal(0, db.CurrentVolumeMl);
+        Assert.Equal(BottleStatus.Empty, db.Status);
+    }
+
+    [Fact]
+    public async Task OnGet_ReturnsNotFound_WhenUserLacksAccess()
+    {
+        using var context = GetInMemoryContext();
+        var (bottle, _) = await SeedBottle(context);
+
+        var page = new QuickPourModel(context);
+        SetMockUser(page, "other-user"); // different user
+
+        var result = await page.OnGetAsync(bottle.Id);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task OnGet_RedirectsToDetails_ForEmptyBottle()
+    {
+        using var context = GetInMemoryContext();
+        var (bottle, whiskey) = await SeedBottle(context, volumeMl: 0, status: BottleStatus.Empty);
+
+        var page = new QuickPourModel(context);
+        SetMockUser(page, "test-user");
+
+        var result = await page.OnGetAsync(bottle.Id);
+
+        var redirect = Assert.IsType<RedirectToPageResult>(result);
+        Assert.Equal("./Details", redirect.PageName);
     }
 }

--- a/WhiskeyTracker.Web/Pages/Whiskies/Details.cshtml
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Details.cshtml
@@ -130,7 +130,7 @@
                                 <td>
                                     <div class="btn-group btn-group-sm">
                                         <a asp-page="./EditBottle" asp-route-id="@bottle.Id" class="btn btn-outline-primary" title="Edit Bottle">Edit</a>
-                                        
+
                                         @if (bottle.IsInfinityBottle)
                                         {
                                             <a asp-page="/Bottles/Infinity" asp-route-id="@bottle.Id" class="btn btn-info text-white" title="View Blend Composition">
@@ -138,11 +138,18 @@
                                             </a>
                                         }
 
+                                        @if (bottle.Status != WhiskeyTracker.Web.Data.BottleStatus.Empty)
+                                        {
+                                            <a asp-page="./QuickPour" asp-route-id="@bottle.Id" class="btn btn-success" title="Log a Quick Pour">
+                                                🥃 Pour
+                                            </a>
+                                        }
+
                                         @if (bottle.Status == WhiskeyTracker.Web.Data.BottleStatus.Opened && !bottle.IsInfinityBottle)
                                         {
                                             @if (bottle.CurrentVolumeMl <= 150)
                                             {
-                                                <a asp-page="./Pour" asp-route-id="@bottle.Id" class="btn btn-success" title="Finish into Infinity Bottle">
+                                                <a asp-page="./Pour" asp-route-id="@bottle.Id" class="btn btn-warning text-dark" title="Finish into Infinity Bottle">
                                                     ♾️ Finish
                                                 </a>
                                             }

--- a/WhiskeyTracker.Web/Pages/Whiskies/QuickPour.cshtml
+++ b/WhiskeyTracker.Web/Pages/Whiskies/QuickPour.cshtml
@@ -1,0 +1,55 @@
+@page "{id:int}"
+@model WhiskeyTracker.Web.Pages.Whiskies.QuickPourModel
+@{
+    ViewData["Title"] = "Quick Pour";
+    var percent = Model.Bottle.CapacityMl > 0
+        ? (double)Model.Bottle.CurrentVolumeMl / Model.Bottle.CapacityMl * 100
+        : 0;
+}
+
+<div class="container mt-4">
+    <div class="row justify-content-center">
+        <div class="col-md-5">
+            <div class="card shadow-sm border-success">
+                <div class="card-header bg-success text-white">
+                    <h4 class="mb-0">🥃 Quick Pour</h4>
+                </div>
+                <div class="card-body">
+                    <h5 class="card-title">@Model.Bottle.Whiskey?.Distillery</h5>
+                    <p class="text-muted mb-1">@Model.Bottle.Whiskey?.Name</p>
+
+                    <div class="mb-3">
+                        <small class="text-muted">@Model.Bottle.CurrentVolumeMl ml / @Model.Bottle.CapacityMl ml remaining</small>
+                        <div class="progress mt-1" style="height: 6px;">
+                            <div class="progress-bar bg-info" role="progressbar" style="width: @percent%"></div>
+                        </div>
+                    </div>
+
+                    <hr />
+
+                    <form method="post">
+                        <div class="mb-4">
+                            <label asp-for="PourAmountOz" class="form-label fw-bold"></label>
+                            <div class="input-group">
+                                <input asp-for="PourAmountOz" class="form-control form-control-lg" type="number"
+                                       min="0.1" max="25" step="0.25" />
+                                <span class="input-group-text">oz</span>
+                            </div>
+                            <span asp-validation-for="PourAmountOz" class="text-danger"></span>
+                            <div class="form-text">1 oz ≈ 30 ml &nbsp;·&nbsp; Standard dram = 1.5 oz &nbsp;·&nbsp; Double = 2 oz</div>
+                        </div>
+
+                        <div class="d-grid gap-2">
+                            <button type="submit" class="btn btn-success btn-lg">Pour</button>
+                            <a asp-page="./Details" asp-route-id="@Model.Bottle.WhiskeyId" class="btn btn-outline-secondary">Cancel</a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}

--- a/WhiskeyTracker.Web/Pages/Whiskies/QuickPour.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/QuickPour.cshtml.cs
@@ -1,0 +1,91 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using WhiskeyTracker.Web.Data;
+
+namespace WhiskeyTracker.Web.Pages.Whiskies;
+
+public class QuickPourModel : PageModel
+{
+    private readonly AppDbContext _context;
+
+    public QuickPourModel(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public Bottle Bottle { get; set; } = default!;
+
+    [BindProperty]
+    [Display(Name = "Pour Amount (oz)")]
+    [Range(0.1, 25.0, ErrorMessage = "Please enter a valid pour amount between 0.1 and 25 oz.")]
+    public double PourAmountOz { get; set; } = 2.0;
+
+    public async Task<IActionResult> OnGetAsync(int id)
+    {
+        var userId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+
+        var bottle = await _context.Bottles
+            .Include(b => b.Whiskey)
+            .Include(b => b.Collection)
+            .FirstOrDefaultAsync(b => b.Id == id);
+
+        if (bottle == null) return NotFound();
+
+        var canAccess = await _context.CollectionMembers
+            .AnyAsync(m => m.UserId == userId && m.CollectionId == bottle.CollectionId);
+
+        if (!canAccess) return NotFound();
+
+        if (bottle.Status == BottleStatus.Empty)
+            return RedirectToPage("./Details", new { id = bottle.WhiskeyId });
+
+        Bottle = bottle;
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync(int id)
+    {
+        var userId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+
+        var myCollectionIds = await _context.CollectionMembers
+            .Where(m => m.UserId == userId)
+            .Select(m => m.CollectionId)
+            .ToListAsync();
+
+        var bottle = await _context.Bottles
+            .Include(b => b.Whiskey)
+            .FirstOrDefaultAsync(b => b.Id == id && b.CollectionId.HasValue && myCollectionIds.Contains(b.CollectionId.Value));
+
+        if (bottle == null) return NotFound();
+
+        if (!ModelState.IsValid)
+        {
+            Bottle = bottle;
+            return Page();
+        }
+
+        var pourMl = (int)Math.Round(PourAmountOz * 29.5735);
+
+        if (bottle.Status == BottleStatus.Full)
+            bottle.Status = BottleStatus.Opened;
+
+        bottle.CurrentVolumeMl -= pourMl;
+
+        if (bottle.CurrentVolumeMl <= 0)
+        {
+            bottle.CurrentVolumeMl = 0;
+            bottle.Status = BottleStatus.Empty;
+            TempData["InfoMessage"] = "You killed the bottle! It has been marked as Empty.";
+        }
+        else
+        {
+            TempData["SuccessMessage"] = $"Poured {PourAmountOz:0.#} oz. {bottle.CurrentVolumeMl} ml remaining.";
+        }
+
+        await _context.SaveChangesAsync();
+
+        return RedirectToPage("./Details", new { id = bottle.WhiskeyId });
+    }
+}


### PR DESCRIPTION
## Summary
Closes #105

- Adds `/Whiskies/QuickPour/{id}` — a simple page to log a single pour from any non-empty bottle (including infinity bottles) without requiring a full tasting session
- Accepts pour amount in oz (defaulting to 2 oz), deducts volume, and handles status transitions (Full→Opened, Opened→Empty)
- Adds a 🥃 Pour button to the bottle inventory table in Whiskey Details for all non-empty bottles
- The existing ♾️ Pour/Finish infinity bottle flow is unchanged

## Test plan
- [x] `dotnet test` passes (50/50, +5 new tests)
- [ ] Verify 🥃 Pour button appears for Full and Opened bottles in Whiskey Details
- [ ] Verify 🥃 Pour button appears for Infinity bottles
- [ ] Verify pour deducts volume and shows remaining ml in success message
- [ ] Verify killing a bottle marks it Empty and shows the appropriate message
- [ ] Verify Empty bottles have no Pour button

🤖 Generated with [Claude Code](https://claude.com/claude-code)