### PR TITLE
chore: update sender email to EvolvingPour@gmail.com

### DIFF
--- a/WhiskeyTracker.Web/appsettings.json
+++ b/WhiskeyTracker.Web/appsettings.json
@@ -21,8 +21,8 @@
     "Port": 587,
     "User": "your_user",
     "Password": "your_password",
-    "SenderEmail": "noreply@whiskeytracker.com",
-    "SenderName": "Whiskey Tracker"
+    "SenderEmail": "EvolvingPour@gmail.com",
+    "SenderName": "Evolving Pour"
   },
   "Authentication": {
     "Google": {


### PR DESCRIPTION
## Summary
Closes #75

Updates `SenderEmail` and `SenderName` in `appsettings.json` to use the EvolvingPour Gmail service account.

## Secrets update required
After merging, update the `SECRETS_ENV_FILE` GitHub secret to include:
\`\`\`
EmailSettings__User=EvolvingPour@gmail.com
EmailSettings__Password=<gmail-app-password>
\`\`\`
A Gmail App Password is required (not the account password): Google Account → Security → 2-Step Verification → App Passwords.

## Test plan
- [ ] Update `SECRETS_ENV_FILE` secret with new credentials
- [ ] Deploy and trigger an email (e.g. new user registration confirmation) to verify delivery from EvolvingPour@gmail.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)