### PR TITLE
Make tasting session pour notes optional (#104)

### DIFF
--- a/WhiskeyTracker.Tests/WizardTests.cs
+++ b/WhiskeyTracker.Tests/WizardTests.cs
@@ -97,6 +97,54 @@ public class WizardTests
     }
 
     [Fact]
+    public async Task OnPost_Succeeds_WhenNotesAreEmpty()
+    {
+        // ARRANGE
+        using var context = GetInMemoryContext();
+        var userId = "test-user";
+        var whiskey = new Whiskey { Name = "Test Whiskey", Distillery = "Test Distillery" };
+        context.Whiskies.Add(whiskey);
+        await context.SaveChangesAsync();
+
+        var collection = new Collection { Name = "Test Collection" };
+        context.Collections.Add(collection);
+        await context.SaveChangesAsync();
+
+        context.CollectionMembers.Add(new CollectionMember { CollectionId = collection.Id, UserId = userId, Role = CollectionRole.Owner });
+
+        var bottle = new Bottle
+        {
+            WhiskeyId = whiskey.Id,
+            CollectionId = collection.Id,
+            UserId = userId,
+            CurrentVolumeMl = 750,
+            Status = BottleStatus.Full
+        };
+        context.Bottles.Add(bottle);
+        await context.SaveChangesAsync();
+
+        var session = new TastingSession { Title = "Test Session", UserId = userId, Date = DateOnly.FromDateTime(DateTime.Now) };
+        context.TastingSessions.Add(session);
+        await context.SaveChangesAsync();
+
+        var pageModel = new WizardModel(context)
+        {
+            SelectedBottleId = bottle.Id,
+            PourAmountOz = 1.0,
+            NewNote = new TastingNote { Notes = null } // No notes
+        };
+        SetMockUser(pageModel, userId);
+
+        // ACT
+        var result = await pageModel.OnPostAsync(session.Id);
+
+        // ASSERT
+        Assert.IsType<RedirectToPageResult>(result);
+        var note = await context.TastingNotes.FirstAsync();
+        Assert.Null(note.Notes);
+    }
+
+    [Fact]
     public async Task OnPost_Fails_WhenOzIsMissing()
     {
         // ARRANGE

--- a/WhiskeyTracker.Web/Pages/Tasting/Wizard.cshtml
+++ b/WhiskeyTracker.Web/Pages/Tasting/Wizard.cshtml
@@ -80,10 +80,9 @@
                         </div>
 
                         <div class="mb-3">
-                            <label asp-for="NewNote.Notes" class="form-label">Impressions</label>
+                            <label asp-for="NewNote.Notes" class="form-label">Impressions <span class="text-muted">(optional)</span></label>
                             <textarea asp-for="NewNote.Notes" class="form-control" rows="3"
                                 placeholder="Nose, Palate, Finish..."></textarea>
-                            <span asp-validation-for="NewNote.Notes" class="text-danger"></span>
                         </div>
 
                         <div class="d-grid">

--- a/WhiskeyTracker.Web/Pages/Tasting/Wizard.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Tasting/Wizard.cshtml.cs
@@ -121,11 +121,6 @@ public class WizardModel : PageModel
             ModelState.AddModelError("SelectedWhiskeyId", "You must select either a Bottle or a Whiskey.");
         }
 
-        if (string.IsNullOrWhiteSpace(NewNote.Notes))
-        {
-            ModelState.AddModelError("NewNote.Notes", "Tasting notes are required.");
-        }
-
         // Re-establish relationships
         NewNote.TastingSessionId = sessionId;
         NewNote.OrderIndex = await _context.TastingNotes.CountAsync(n => n.TastingSessionId == sessionId) + 1;


### PR DESCRIPTION
## Summary
- Removes the manual `ModelState` validation that forced tasting notes to be required in the Wizard
- Labels the Impressions field as `(optional)` in the UI
- Adds a test to `WizardTests` confirming a pour with null notes succeeds

## Test plan
- [x] `dotnet test` — all 53 tests pass
- [ ] Manually verify a pour can be logged in the Wizard without entering any impressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)