### PR TITLE
Fix CI/CD: Resolve log_destination conflict in psql/pg_dump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
       id: check_migrations
       run: |
         # Get latest from DB
-        DB_MIGRATION=$(kubectl exec deployment/postgres -- psql -U postgres -d whiskey_prod -t -c "SELECT \"MigrationId\" FROM \"__EFMigrationsHistory\" ORDER BY \"MigrationId\" DESC LIMIT 1;" | xargs)
+        DB_MIGRATION=$(kubectl exec deployment/postgres -- sh -c "unset PGOPTIONS; psql -U postgres -d whiskey_prod -t -c 'SELECT \"MigrationId\" FROM \"__EFMigrationsHistory\" ORDER BY \"MigrationId\" DESC LIMIT 1;'" | xargs)
         
         # Get latest from code
         LOCAL_MIGRATION=$(find WhiskeyTracker.Web/Migrations -name "[0-9]*.cs" | sort | tail -n 1 | xargs basename -s .cs)
@@ -135,7 +135,7 @@ jobs:
         # Ensure directory exists on PVC
         kubectl exec content-loader -- mkdir -p /app/backups
         # Stream pg_dump through runner into PVC
-        kubectl exec deployment/postgres -- pg_dump -U postgres whiskey_prod | \
+        kubectl exec deployment/postgres -- sh -c "unset PGOPTIONS; pg_dump -U postgres whiskey_prod" | \
           kubectl exec -i content-loader -- sh -c "cat > /app/backups/whiskey_prod_$TIMESTAMP.sql"
         # Keep last 7 days of backups on PVC
         kubectl exec content-loader -- find /app/backups -name "*.sql" -mtime +7 -delete


### PR DESCRIPTION
## Problem
The production database is configured with `log_destination=jsonlog` in its `PGOPTIONS`. When CI/CD scripts run `psql` or `pg_dump` via `kubectl exec`, they inherit these options, causing a fatal error because `log_destination` cannot be changed at runtime.

## Fix
Wrapped all `psql` and `pg_dump` calls in `sh -c " unset PGOPTIONS