### PR TITLE
fix: resolve infinity pour 404, switch to oz input, add missing tests

### DIFF
--- a/WhiskeyTracker.Tests/PourTests.cs
+++ b/WhiskeyTracker.Tests/PourTests.cs
@@ -72,7 +72,7 @@ public class PourTests
         // ASSERT
         Assert.IsType<PageResult>(result);
         Assert.Equal(sourceBottle.Id, pageModel.SourceBottle.Id);
-        Assert.Equal(100, pageModel.PourAmountMl); 
+        Assert.Equal(3.4, pageModel.PourAmountOz);
 
         // Check the dropdown list - Should only have the ONE open infinity bottle
         var options = Assert.IsType<SelectList>(pageModel.InfinityBottles);
@@ -108,7 +108,7 @@ public class PourTests
         {
             SourceBottleId = source.Id,
             TargetInfinityBottleId = target.Id,
-            PourAmountMl = 40
+            PourAmountOz = 1.35 // 1.35 oz * 29.5735 = ~40ml
         };
         SetMockUser(pageModel, "test-user");
 
@@ -126,16 +126,129 @@ public class PourTests
         var dbTarget = await context.Bottles.AsNoTracking().FirstOrDefaultAsync(b => b.Id == target.Id);
         Assert.NotNull(dbSource);
         Assert.NotNull(dbTarget);
-        
+
         // Adjusted expectation to match current behavior (Bottle is emptied)
-        Assert.Equal(0, dbSource.CurrentVolumeMl); 
-        Assert.Equal(540, dbTarget.CurrentVolumeMl); // 500 + 40
-        Assert.Equal(BottleStatus.Empty, dbSource.Status); 
+        Assert.Equal(0, dbSource.CurrentVolumeMl);
+        Assert.Equal(540, dbTarget.CurrentVolumeMl); // 500 + 40ml (1.35 oz rounds to 40ml)
+        Assert.Equal(BottleStatus.Empty, dbSource.Status);
 
         // 3. Check History Log
         var log = await context.BlendComponents.FirstOrDefaultAsync();
         Assert.NotNull(log);
         Assert.Equal(40, log.AmountAddedMl);
+    }
+
+    [Fact]
+    public async Task OnGet_ReturnsNotFound_WhenUserLacksAccess()
+    {
+        // ARRANGE
+        using var context = GetInMemoryContext();
+        var whiskey = new Whiskey { Name = "Bourbon" };
+        context.Whiskies.Add(whiskey);
+        await context.SaveChangesAsync();
+
+        var collection = new Collection { Id = 1, Name = "Private Collection" };
+        context.Collections.Add(collection);
+        context.CollectionMembers.Add(new CollectionMember { CollectionId = 1, UserId = "owner-user", Role = CollectionRole.Owner });
+
+        var bottle = new Bottle { WhiskeyId = whiskey.Id, CurrentVolumeMl = 200, Status = BottleStatus.Opened, CollectionId = 1 };
+        context.Bottles.Add(bottle);
+        await context.SaveChangesAsync();
+
+        var pageModel = new PourModel(context, new FakeTimeProvider(DateTimeOffset.UtcNow));
+        SetMockUser(pageModel, "other-user");
+
+        // ACT
+        var result = await pageModel.OnGetAsync(bottle.Id);
+
+        // ASSERT
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task OnGet_ReturnsNotFound_WhenBottleDoesNotExist()
+    {
+        // ARRANGE
+        using var context = GetInMemoryContext();
+        var pageModel = new PourModel(context, new FakeTimeProvider(DateTimeOffset.UtcNow));
+        SetMockUser(pageModel, "test-user");
+
+        // ACT
+        var result = await pageModel.OnGetAsync(99999);
+
+        // ASSERT
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task OnPost_ReturnsPage_WhenModelStateIsInvalid()
+    {
+        // ARRANGE
+        using var context = GetInMemoryContext();
+        var whiskey = new Whiskey { Name = "Bourbon" };
+        context.Whiskies.Add(whiskey);
+        await context.SaveChangesAsync();
+
+        var collection = new Collection { Id = 1, Name = "Test Bar" };
+        context.Collections.Add(collection);
+        context.CollectionMembers.Add(new CollectionMember { CollectionId = 1, UserId = "test-user", Role = CollectionRole.Owner });
+
+        var source = new Bottle { WhiskeyId = whiskey.Id, CurrentVolumeMl = 100, Status = BottleStatus.Opened, CollectionId = 1 };
+        context.Bottles.Add(source);
+        await context.SaveChangesAsync();
+
+        var pageModel = new PourModel(context, new FakeTimeProvider(DateTimeOffset.UtcNow))
+        {
+            SourceBottleId = source.Id,
+            TargetInfinityBottleId = 0,
+            PourAmountOz = 0 // invalid: below minimum of 0.1
+        };
+        SetMockUser(pageModel, "test-user");
+        pageModel.ModelState.AddModelError("PourAmountOz", "Please enter a valid pour amount between 0.1 and 25 oz.");
+
+        // ACT
+        var result = await pageModel.OnPostAsync();
+
+        // ASSERT
+        Assert.IsType<PageResult>(result);
+        // No DB changes should have occurred
+        var dbSource = await context.Bottles.AsNoTracking().FirstAsync(b => b.Id == source.Id);
+        Assert.Equal(100, dbSource.CurrentVolumeMl);
+    }
+
+    [Fact]
+    public async Task OnPost_ReturnsNotFound_WhenSourceBottleNotOwned()
+    {
+        // ARRANGE
+        using var context = GetInMemoryContext();
+        var whiskey = new Whiskey { Name = "Bourbon" };
+        context.Whiskies.Add(whiskey);
+        await context.SaveChangesAsync();
+
+        var otherCollection = new Collection { Id = 1, Name = "Someone Else's Bar" };
+        context.Collections.Add(otherCollection);
+        context.CollectionMembers.Add(new CollectionMember { CollectionId = 1, UserId = "other-user", Role = CollectionRole.Owner });
+
+        var source = new Bottle { WhiskeyId = whiskey.Id, CurrentVolumeMl = 100, Status = BottleStatus.Opened, CollectionId = 1 };
+        context.Bottles.Add(source);
+        await context.SaveChangesAsync();
+
+        var pageModel = new PourModel(context, new FakeTimeProvider(DateTimeOffset.UtcNow))
+        {
+            SourceBottleId = source.Id,
+            TargetInfinityBottleId = 0,
+            PourAmountOz = 1.5
+        };
+        SetMockUser(pageModel, "attacker-user"); // not a member of any collection
+
+        // ACT
+        var result = await pageModel.OnPostAsync();
+
+        // ASSERT
+        Assert.IsType<NotFoundResult>(result);
+        // Source bottle should be untouched
+        var dbSource = await context.Bottles.AsNoTracking().FirstAsync(b => b.Id == source.Id);
+        Assert.Equal(100, dbSource.CurrentVolumeMl);
     }
 
     [Fact]
@@ -160,7 +273,7 @@ public class PourTests
         {
             SourceBottleId = source.Id,
             TargetInfinityBottleId = target.Id,
-            PourAmountMl = 50 // Pouring everything
+            PourAmountOz = 1.7 // 1.7 oz * 29.5735 = ~50ml
         };
         SetMockUser(pageModel, "test-user");
 

--- a/WhiskeyTracker.Web/Pages/Whiskies/Pour.cshtml
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Pour.cshtml
@@ -17,20 +17,26 @@
                     <hr />
 
                     <form method="post">
-                        <input type="hidden" asp-for="SourceBottle.Id" />
+                        <input type="hidden" asp-for="SourceBottleId" />
 
                         @if (Model.InfinityBottles.Any())
                         {
                             <div class="form-group mb-3">
                                 <label asp-for="TargetInfinityBottleId" class="form-label fw-bold">Destination Bottle</label>
-                                <select asp-for="TargetInfinityBottleId" class="form-select" asp-items="Model.InfinityBottles"></select>
+                                <select asp-for="TargetInfinityBottleId" class="form-select bg-body text-body" asp-items="Model.InfinityBottles">
+                                    <option value="">-- Select Infinity Bottle --</option>
+                                </select>
                                 <span asp-validation-for="TargetInfinityBottleId" class="text-danger"></span>
                             </div>
 
                             <div class="form-group mb-3">
-                                <label asp-for="PourAmountMl" class="form-label fw-bold">Amount to Pour (ml)</label>
-                                <input asp-for="PourAmountMl" class="form-control" type="number" min="1" max="300" />
-                                <span asp-validation-for="PourAmountMl" class="text-danger"></span>
+                                <label asp-for="PourAmountOz" class="form-label fw-bold"></label>
+                                <div class="input-group">
+                                    <input asp-for="PourAmountOz" class="form-control" type="number" min="0.1" max="25" step="0.25" />
+                                    <span class="input-group-text">oz</span>
+                                </div>
+                                <div class="form-text">1 oz ≈ 30 ml &nbsp;·&nbsp; Standard dram = 1.5 oz &nbsp;·&nbsp; Double = 2 oz</div>
+                                <span asp-validation-for="PourAmountOz" class="text-danger"></span>
                             </div>
 
                             <div class="d-grid gap-2">

--- a/WhiskeyTracker.Web/Pages/Whiskies/Pour.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Pour.cshtml.cs
@@ -25,8 +25,9 @@ public class PourModel : PageModel
     public int TargetInfinityBottleId { get; set; }
 
     [BindProperty]
-    [Display(Name = "Amount to Pour (ml)")]
-    public int PourAmountMl { get; set; }
+    [Display(Name = "Pour Amount (oz)")]
+    [Range(0.1, 25.0, ErrorMessage = "Please enter a valid pour amount between 0.1 and 25 oz.")]
+    public double PourAmountOz { get; set; } = 2.0;
 
     public Bottle SourceBottle { get; set; } = default!;
     public SelectList InfinityBottles { get; set; } = default!;
@@ -49,7 +50,7 @@ public class PourModel : PageModel
         SourceBottle = bottle;
         SourceBottleId = bottle.Id;
 
-        PourAmountMl = bottle.CurrentVolumeMl;
+        PourAmountOz = Math.Round(bottle.CurrentVolumeMl / 29.5735, 1);
 
         // Find Infinity Bottles in ANY collection I am a member of
         // This allows cross-collection pouring? Maybe restricting to SAME collection is safer?
@@ -83,25 +84,37 @@ public class PourModel : PageModel
             .Include(b => b.Whiskey)
             .FirstOrDefaultAsync(b => b.Id == SourceBottleId && b.CollectionId.HasValue && myCollectionIds.Contains(b.CollectionId.Value));
 
+        if (source == null) return NotFound();
+
+        if (!ModelState.IsValid)
+        {
+            SourceBottle = source;
+            var infinityBottles = await _context.Bottles
+                .Include(b => b.Whiskey)
+                .Where(b => b.IsInfinityBottle && b.Id != source.Id && b.Status != BottleStatus.Full && b.CollectionId.HasValue && myCollectionIds.Contains(b.CollectionId.Value))
+                .ToListAsync();
+            InfinityBottles = new SelectList(infinityBottles, "Id", "Whiskey.Name");
+            return Page();
+        }
+
         var target = await _context.Bottles
             .Include(b => b.Whiskey)
             .FirstOrDefaultAsync(b => b.Id == TargetInfinityBottleId && b.CollectionId.HasValue && myCollectionIds.Contains(b.CollectionId.Value));
 
-        if (source == null || target == null) 
-        {
-            return NotFound();
-        }
+        if (target == null) return NotFound();
+
+        var pourMl = (int)Math.Round(PourAmountOz * 29.5735);
 
         source.CurrentVolumeMl = 0;
         source.Status = BottleStatus.Empty;
 
-        target.CurrentVolumeMl += PourAmountMl;
+        target.CurrentVolumeMl += pourMl;
 
         var blendLog = new BlendComponent
         {
             SourceBottleId = source.Id,
             InfinityBottleId = target.Id,
-            AmountAddedMl = PourAmountMl,
+            AmountAddedMl = pourMl,
             DateAdded = DateOnly.FromDateTime(_timeProvider.GetLocalNow().DateTime)
         };
         _context.BlendComponents.Add(blendLog);


### PR DESCRIPTION
## Summary

- **404 on confirm pour**: Hidden field was bound to `SourceBottle.Id` (not a `[BindProperty]`) so `SourceBottleId` was always 0 on POST, causing the source bottle lookup to fail
- **Oz input**: Replaced `PourAmountMl` (int, ml) with `PourAmountOz` (double, oz) with `[Range]` validation and oz→ml conversion, matching the QuickPour and Tasting Wizard pattern
- **Dropdown**: Added placeholder option (`-- Select Infinity Bottle --`) and `bg-body text-body` classes to match the tasting wizard style
- **ModelState bug**: `OnPostAsync` was not checking `ModelState.IsValid`, so the `[Range]` validation on pour amount was silently ignored; fixed with proper page re-render on invalid state
- **Tests**: Added 4 new tests — `OnGet` NotFound for unauthorized/missing bottle, `OnPost` returns Page on invalid model state, `OnPost` NotFound for unauthorized source bottle; updated existing tests from ml to oz

## Test plan

- [ ] Navigate to an open bottle and click "Pour into Infinity" — confirm page loads
- [ ] Select a destination infinity bottle and enter an oz amount — confirm pour succeeds and redirects to bottle details
- [ ] Submit with an invalid oz amount (0 or blank) — confirm validation error shown, no data changed
- [ ] Verify the infinity bottle blend composition page reflects the correct ml amount after pour
- [ ] `dotnet test` passes (80/80)

🤖 Generated with [Claude Code](https://claude.com/claude-code)