### PR TITLE
🛡️ Sentinel: [LOW] Prevent 500 error on non-local returnUrl

### DIFF
--- a/WhiskeyTracker.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/WhiskeyTracker.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -164,7 +164,14 @@ namespace WhiskeyTracker.Web.Areas.Identity.Pages.Account
                     else
                     {
                         await _signInManager.SignInAsync(user, isPersistent: false);
-                        return LocalRedirect(returnUrl);
+                        if (Url.IsLocalUrl(returnUrl))
+                        {
+                            return LocalRedirect(returnUrl);
+                        }
+                        else
+                        {
+                            return LocalRedirect(Url.Content("~/"));
+                        }
                     }
                 }
                 foreach (var error in result.Errors)


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: Unhandled exception (500 error) when a non-local or malformed `returnUrl` is provided to `LocalRedirect` during user registration.
🎯 Impact: Degraded user experience or minor DoS (crashing the specific request) if an attacker crafts a link with an external `returnUrl`.
🔧 Fix: Added `Url.IsLocalUrl()` validation before calling `LocalRedirect()`, falling back to `~/` for external URLs to fail gracefully.
✅ Verification: Passed full test suite (`dotnet test`).

---
*PR created automatically by Jules for task [10953164834523718456](https://jules.google.com/task/10953164834523718456) started by @whwar9739*