### PR TITLE
Display brand and expression in tasting notes

### DIFF
--- a/WhiskeyTracker.Tests/WizardTests.cs
+++ b/WhiskeyTracker.Tests/WizardTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using WhiskeyTracker.Web.Data;
 using WhiskeyTracker.Web.Pages.Tasting;
 using Microsoft.EntityFrameworkCore;
@@ -262,5 +263,35 @@ public class WizardTests : TestBase
 
         var finishTags = note.TastingNoteTags.Where(t => t.Field == TastingField.Finish).Select(t => t.Tag.Name).ToList();
         Assert.Contains("long", finishTags);
+    }
+
+    [Fact]
+    public async Task OnGet_PopulatesWhiskeyOptionsWithBrandAndName()
+    {
+        // ARRANGE
+        using var context = GetInMemoryContext();
+        var userId = "test-user";
+        context.Whiskies.AddRange(
+            new Whiskey { Brand = "Macallan", Name = "12 Year", Distillery = "Macallan" },
+            new Whiskey { Brand = "Buffalo Trace", Name = "Bourbon", Distillery = "Buffalo Trace" }
+        );
+        await context.SaveChangesAsync();
+
+        var session = new TastingSession { Title = "Session", UserId = userId, Date = DateOnly.FromDateTime(DateTime.Now) };
+        context.TastingSessions.Add(session);
+        await context.SaveChangesAsync();
+
+        var hubMock = GetMockHubContext();
+        var service = new TastingSessionService(context, hubMock.Object);
+        var pageModel = new WizardModel(context, hubMock.Object, service);
+        SetMockUser(pageModel, userId);
+
+        // ACT
+        await pageModel.OnGetAsync(session.Id);
+
+        // ASSERT
+        var options = pageModel.WhiskeyOptions.Cast<SelectListItem>().ToList();
+        Assert.Contains(options, o => o.Text == "Buffalo Trace Bourbon");
+        Assert.Contains(options, o => o.Text == "Macallan 12 Year");
     }
 }

--- a/WhiskeyTracker.Web/Pages/Index.cshtml
+++ b/WhiskeyTracker.Web/Pages/Index.cshtml
@@ -138,7 +138,7 @@ else
         {
             <div class="list-group-item d-flex justify-content-between align-items-center">
                 <div>
-                    <h6 class="mb-0 fw-bold">@note.Whiskey.Name</h6>
+                    <h6 class="mb-0 fw-bold">@note.Whiskey.Brand @note.Whiskey.Name</h6>
                     @if (note.TastingNoteTags.Any())
                     {
                         <div class="mt-1">

--- a/WhiskeyTracker.Web/Pages/Tasting/Details.cshtml
+++ b/WhiskeyTracker.Web/Pages/Tasting/Details.cshtml
@@ -50,7 +50,7 @@
                             <div class="d-flex justify-content-between">
                                 <h5 class="card-title fw-bold">
                                     <span class="badge bg-secondary rounded-pill me-2">#@note.OrderIndex</span>
-                                    @note.Whiskey.Name
+                                    @note.Whiskey.Brand @note.Whiskey.Name
                                 </h5>
                                 <div class="text-warning opacity-75">
                                     @for (int i = 0; i < note.Rating; i++)

--- a/WhiskeyTracker.Web/Pages/Tasting/Wizard.cshtml
+++ b/WhiskeyTracker.Web/Pages/Tasting/Wizard.cshtml
@@ -205,7 +205,7 @@
                             <div class="d-flex w-100 justify-content-between align-items-start">
                                 <h5 class="mb-1">
                                     <span class="badge bg-secondary rounded-pill me-2">#@note.OrderIndex</span>
-                                    @note.Whiskey.Name
+                                    @note.Whiskey.Brand @note.Whiskey.Name
                                 </h5>
                                 <div class="d-flex align-items-center gap-2">
                                     @if (note.PourAmountMl > 0)

--- a/WhiskeyTracker.Web/Pages/Tasting/Wizard.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Tasting/Wizard.cshtml.cs
@@ -320,11 +320,12 @@ public class WizardModel : PageModel
         }), "Id", "Text");
 
         var whiskies = await _context.Whiskies
-            .OrderBy(w => w.Name)
-            .Select(w => new { w.Id, w.Name })
+            .OrderBy(w => w.Brand)
+            .ThenBy(w => w.Name)
+            .Select(w => new { w.Id, Text = $"{w.Brand} {w.Name}" })
             .ToListAsync();
 
-        WhiskeyOptions = new SelectList(whiskies, "Id", "Name");
+        WhiskeyOptions = new SelectList(whiskies, "Id", "Text");
 
         AvailableTags = await _context.Tags
             .Where(t => t.IsApproved || t.CreatedByUserId == userId)


### PR DESCRIPTION
This change ensures that tasting notes consistently display both the brand and the expression (name) of the whiskey. 

Key changes:
- Modified `WhiskeyTracker.Web/Pages/Index.cshtml` (Dashboard) to include the brand in "Recent Sips".
- Modified `WhiskeyTracker.Web/Pages/Tasting/Details.cshtml` to include the brand in the tasting note titles.
- Modified `WhiskeyTracker.Web/Pages/Tasting/Wizard.cshtml` to include the brand in the "Tonight's Lineup" section.
- Updated `WhiskeyTracker.Web/Pages/Tasting/Wizard.cshtml.cs` to include the brand in the `WhiskeyOptions` selection list and order them by brand then name.
- Added a unit test in `WhiskeyTracker.Tests/WizardTests.cs` to verify the combined brand and name display in selection options.

Fixes #145

---
*PR created automatically by Jules for task [4692284117328040993](https://jules.google.com/task/4692284117328040993) started by @whwar9739*