### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF in Google Photos Integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-24 - SSRF Vulnerability in Google Photos Integration
+**Vulnerability:** The `GooglePhotoUrl` property in `Create.cshtml.cs` and `Edit.cshtml.cs` was passed directly to `HttpClient.GetAsync()` without validation. This allowed an attacker to submit an arbitrary URL, potentially exploiting Server-Side Request Forgery (SSRF) to scan internal networks or access sensitive resources on behalf of the server.
+**Learning:** Whenever the application fetches resources from user-provided URLs, the destination must be explicitly validated. Do not assume the frontend (which might set the URL via JavaScript) guarantees a safe endpoint.
+**Prevention:** Use `Uri.TryCreate` to ensure the URL is absolute, verify `uri.Scheme == Uri.UriSchemeHttps`, and check that `uri.Host` ends with a trusted domain (e.g., `.googleusercontent.com`) before making the HTTP request.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,9 +48,17 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !uri.Host.EndsWith(".googleusercontent.com", StringComparison.OrdinalIgnoreCase))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
+            var response = await httpClient.GetAsync(uri);
             if (response.IsSuccessStatusCode)
             {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,9 +62,17 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !uri.Host.EndsWith(".googleusercontent.com", StringComparison.OrdinalIgnoreCase))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
+            var response = await httpClient.GetAsync(uri);
             if (response.IsSuccessStatusCode)
             {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();


### PR DESCRIPTION
🚨 **Severity: HIGH**
💡 **Vulnerability:** Unvalidated URL passed to `HttpClient.GetAsync()`, potentially enabling Server-Side Request Forgery (SSRF) vulnerabilities where an attacker could probe internal networks or external sites via the backend.
🎯 **Impact:** An attacker could submit malicious URLs through the `GooglePhotoUrl` property and make the server send unauthorized requests.
🔧 **Fix:** Introduced URI validation checking for `https` and `.googleusercontent.com` domain before requesting image bytes.
✅ **Verification:** Verified by running all unit tests using `dotnet test` ensuring no regressions were introduced. Evaluated via `dotnet build`. Added documentation regarding the fix to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [12410709994773502741](https://jules.google.com/task/12410709994773502741) started by @whwar9739*