### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF and Path Traversal in Image Uploads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,10 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2026-04-21 - Prevent SSRF and Path Traversal in Image Uploads
+**Vulnerability:** The application was vulnerable to Server-Side Request Forgery (SSRF) and Path Traversal. In `Create.cshtml.cs` and `Edit.cshtml.cs`, `GooglePhotoUrl` was used in `HttpClient.GetAsync()` without validation, allowing potential access to internal network resources. Additionally, `ImageUpload.FileName` was appended directly to a GUID when saving files, which could allow path traversal if a malicious filename was provided.
+**Learning:** Always validate user-provided URLs before making HTTP requests, ensuring they use HTTPS and restrict domains to trusted sources. For file uploads, never trust the user-provided filename; generate a safe, unique filename and only preserve the original extension.
+**Prevention:**
+1. Validate `GooglePhotoUrl` using `Uri.TryCreate`, checking `Uri.SchemeHttps` and specific trusted domains (e.g., `uriResult.Host.EndsWith(".googleusercontent.com")`).
+2. Use `Path.GetExtension(ImageUpload.FileName)` when generating safe server-side file paths to prevent directory traversal attacks.

--- a/WhiskeyTracker.Tests/WhiskiesTests.cs
+++ b/WhiskeyTracker.Tests/WhiskiesTests.cs
@@ -126,7 +126,7 @@ public class WhiskiesTests : TestBase
         Assert.IsType<RedirectToPageResult>(result);
         var whiskey = await context.Whiskies.FirstAsync();
         Assert.Equal("Test Whiskey", whiskey.Name);
-        Assert.Contains("test.jpg", whiskey.ImageFileName); // Confirms filename was generated
+        Assert.EndsWith(".jpg", whiskey.ImageFileName); // Confirms file extension is correct and generated
     }
 
     [Fact]
@@ -477,7 +477,7 @@ public class WhiskiesTests : TestBase
         Assert.NotNull(updatedWhiskey);
         Assert.NotNull(updatedWhiskey.ImageFileName);
         Assert.NotEqual(oldFileName, updatedWhiskey.ImageFileName);
-        Assert.Contains(newFileName, updatedWhiskey.ImageFileName);
+        Assert.EndsWith(".jpg", updatedWhiskey.ImageFileName);
         Assert.False(File.Exists(oldFilePath));
         Assert.True(File.Exists(Path.Combine(tempPath, "images", updatedWhiskey.ImageFileName)));
 

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,9 +48,18 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            // SECURITY: Validate URL to prevent SSRF
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uriResult)
+                || uriResult.Scheme != Uri.UriSchemeHttps
+                || !uriResult.Host.EndsWith(".googleusercontent.com", StringComparison.OrdinalIgnoreCase))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
+            var response = await httpClient.GetAsync(uriResult);
             if (response.IsSuccessStatusCode)
             {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();
@@ -65,7 +74,9 @@ public class CreateModel : PageModel
         }
         else if (ImageUpload != null)
         {
-            var uniqueFileName = Guid.NewGuid().ToString() + "_" + ImageUpload.FileName;
+            // SECURITY: Prevent Path Traversal by generating unique name with only the extension
+            var extension = Path.GetExtension(ImageUpload.FileName);
+            var uniqueFileName = Guid.NewGuid().ToString() + extension;
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
 
             if (!Directory.Exists(uploadsFolder))

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,9 +62,18 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            // SECURITY: Validate URL to prevent SSRF
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uriResult)
+                || uriResult.Scheme != Uri.UriSchemeHttps
+                || !uriResult.Host.EndsWith(".googleusercontent.com", StringComparison.OrdinalIgnoreCase))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
+            var response = await httpClient.GetAsync(uriResult);
             if (response.IsSuccessStatusCode)
             {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();
@@ -86,7 +95,9 @@ public class EditModel : PageModel
         }
         else if (ImageUpload != null)
         {
-            var uniqueFileName = Guid.NewGuid().ToString() + "_" + ImageUpload.FileName;
+            // SECURITY: Prevent Path Traversal by generating unique name with only the extension
+            var extension = Path.GetExtension(ImageUpload.FileName);
+            var uniqueFileName = Guid.NewGuid().ToString() + extension;
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application was vulnerable to Server-Side Request Forgery (SSRF) and Path Traversal. In `Create.cshtml.cs` and `Edit.cshtml.cs`, `GooglePhotoUrl` was used in `HttpClient.GetAsync()` without validation, allowing potential access to internal network resources. Additionally, `ImageUpload.FileName` was appended directly to a GUID when saving files, which could allow path traversal if a malicious filename was provided.
🎯 Impact: Exploitation of the SSRF vulnerability could allow an attacker to probe internal networks or exploit internal services. Exploitation of the path traversal could allow arbitrary files to be written to the server's filesystem, potentially leading to remote code execution.
🔧 Fix: Validated `GooglePhotoUrl` using `Uri.TryCreate`, checking `Uri.SchemeHttps` and specific trusted domains (e.g., `uriResult.Host.EndsWith(".googleusercontent.com")`). Used `Path.GetExtension(ImageUpload.FileName)` when generating safe server-side file paths to prevent directory traversal attacks.
✅ Verification: Ran unit tests to verify proper functionality of the upload feature with safe extensions.

---
*PR created automatically by Jules for task [12262721680382710594](https://jules.google.com/task/12262721680382710594) started by @whwar9739*