### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF and Path Traversal in Image Handling

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-04-22 - Unvalidated URI Input Causing SSRF and Path Traversal in File Uploads
+**Vulnerability:** The application was vulnerable to Server-Side Request Forgery (SSRF) by unconditionally passing user-provided `GooglePhotoUrl` inputs to `HttpClient.GetAsync()`. Additionally, file uploads used the original `ImageUpload.FileName` directly when saving to disk, introducing a Path Traversal risk and naming collisions.
+**Learning:** Never trust external URIs for backend HTTP requests without validating the protocol and host. Similarly, never trust user-supplied filenames for file system operations.
+**Prevention:** For SSRF protection, validate that the input URI uses `https://` and points to a trusted domain (e.g., `.googleusercontent.com`) before dispatching a request. For Path Traversal, always extract only the extension using `Path.GetExtension(FileName)` and prepend it with a locally generated `Guid` before writing to disk.

--- a/WhiskeyTracker.Tests/WhiskiesTests.cs
+++ b/WhiskeyTracker.Tests/WhiskiesTests.cs
@@ -44,7 +44,7 @@ public class WhiskiesTests : TestBase
         await context.SaveChangesAsync();
 
         var legacyService = new WhiskeyTracker.Web.Services.LegacyMigrationService(context);
-        
+
         // Search matches Brand
         var pageModel = new IndexModel(context, legacyService) { SearchString = "William" };
         SetMockUser(pageModel, "test-user");
@@ -126,7 +126,7 @@ public class WhiskiesTests : TestBase
         Assert.IsType<RedirectToPageResult>(result);
         var whiskey = await context.Whiskies.FirstAsync();
         Assert.Equal("Test Whiskey", whiskey.Name);
-        Assert.Contains("test.jpg", whiskey.ImageFileName); // Confirms filename was generated
+        Assert.EndsWith(".jpg", whiskey.ImageFileName); // Confirms filename was generated
     }
 
     [Fact]
@@ -140,8 +140,8 @@ public class WhiskiesTests : TestBase
 
         var pageModel = new CreateModel(context, mockEnv.Object)
         {
-            NewWhiskey = new Whiskey 
-            { 
+            NewWhiskey = new Whiskey
+            {
                 Name = "No Cask Whiskey",
                 Distillery = "Test Distillery",
                 CaskType = null // Explicitly null
@@ -477,7 +477,7 @@ public class WhiskiesTests : TestBase
         Assert.NotNull(updatedWhiskey);
         Assert.NotNull(updatedWhiskey.ImageFileName);
         Assert.NotEqual(oldFileName, updatedWhiskey.ImageFileName);
-        Assert.Contains(newFileName, updatedWhiskey.ImageFileName);
+        Assert.EndsWith(".jpg", updatedWhiskey.ImageFileName);
         Assert.False(File.Exists(oldFilePath));
         Assert.True(File.Exists(Path.Combine(tempPath, "images", updatedWhiskey.ImageFileName)));
 

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,24 +48,35 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
-            if (response.IsSuccessStatusCode)
+            if (Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var parsedUri) &&
+                parsedUri.Scheme == Uri.UriSchemeHttps &&
+                parsedUri.Host.EndsWith(".googleusercontent.com"))
             {
-                var imageBytes = await response.Content.ReadAsByteArrayAsync();
-                var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
-                var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
-                if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
-                
-                var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-                await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
-                NewWhiskey.ImageFileName = uniqueFileName;
+                using var httpClient = new HttpClient();
+                httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
+                var response = await httpClient.GetAsync(GooglePhotoUrl);
+                if (response.IsSuccessStatusCode)
+                {
+                    var imageBytes = await response.Content.ReadAsByteArrayAsync();
+                    var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
+                    var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
+                    if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
+
+                    var filePath = Path.Combine(uploadsFolder, uniqueFileName);
+                    await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
+                    NewWhiskey.ImageFileName = uniqueFileName;
+                }
+            }
+            else
+            {
+                ModelState.AddModelError(string.Empty, "Invalid Google Photo URL. Must be a secure HTTPS connection to a trusted Google host.");
+                return Page();
             }
         }
         else if (ImageUpload != null)
         {
-            var uniqueFileName = Guid.NewGuid().ToString() + "_" + ImageUpload.FileName;
+            var extension = Path.GetExtension(ImageUpload.FileName);
+            var uniqueFileName = Guid.NewGuid().ToString() + extension;
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
 
             if (!Directory.Exists(uploadsFolder))
@@ -74,7 +85,7 @@ public class CreateModel : PageModel
             }
 
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-            
+
             using (var fileStream = new FileStream(filePath, FileMode.Create))
             {
                 await ImageUpload.CopyToAsync(fileStream);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,31 +62,42 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
-            if (response.IsSuccessStatusCode)
+            if (Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var parsedUri) &&
+                parsedUri.Scheme == Uri.UriSchemeHttps &&
+                parsedUri.Host.EndsWith(".googleusercontent.com"))
             {
-                var imageBytes = await response.Content.ReadAsByteArrayAsync();
-                var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
-                var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
-                var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-
-                if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
-                await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
-                
-                if (!string.IsNullOrEmpty(Whiskey.ImageFileName))
+                using var httpClient = new HttpClient();
+                httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
+                var response = await httpClient.GetAsync(GooglePhotoUrl);
+                if (response.IsSuccessStatusCode)
                 {
-                    var oldPath = Path.Combine(uploadsFolder, Whiskey.ImageFileName);
-                    if (System.IO.File.Exists(oldPath)) System.IO.File.Delete(oldPath);
-                }
+                    var imageBytes = await response.Content.ReadAsByteArrayAsync();
+                    var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
+                    var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
+                    var filePath = Path.Combine(uploadsFolder, uniqueFileName);
 
-                Whiskey.ImageFileName = uniqueFileName;
+                    if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
+                    await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
+
+                    if (!string.IsNullOrEmpty(Whiskey.ImageFileName))
+                    {
+                        var oldPath = Path.Combine(uploadsFolder, Whiskey.ImageFileName);
+                        if (System.IO.File.Exists(oldPath)) System.IO.File.Delete(oldPath);
+                    }
+
+                    Whiskey.ImageFileName = uniqueFileName;
+                }
+            }
+            else
+            {
+                ModelState.AddModelError(string.Empty, "Invalid Google Photo URL. Must be a secure HTTPS connection to a trusted Google host.");
+                return Page();
             }
         }
         else if (ImageUpload != null)
         {
-            var uniqueFileName = Guid.NewGuid().ToString() + "_" + ImageUpload.FileName;
+            var extension = Path.GetExtension(ImageUpload.FileName);
+            var uniqueFileName = Guid.NewGuid().ToString() + extension;
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
 


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Unvalidated external HTTP fetch and trusting file name parameters during uploads exposed the application to Server-Side Request Forgery (SSRF) and Path Traversal attacks.
🎯 **Impact**: Allowed internal network scanning or retrieving arbitrary content through SSRF, and writing/overwriting arbitrary server files via Path Traversal.
🔧 **Fix**: Implemented strict URI parsing validating HTTPS scheme and `.googleusercontent.com` host before executing HttpClient.GetAsync. In image upload routes, updated filename logic to strip the arbitrary file name and construct the save path using only the extension and a `Guid.NewGuid()`. 
✅ **Verification**: Execute `dotnet test` and review `WhiskiesTests.cs` to ensure image file generation constraints verify correctly against extensions instead of original filenames.

---
*PR created automatically by Jules for task [7035287365858174961](https://jules.google.com/task/7035287365858174961) started by @whwar9739*