### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Server-Side Request Forgery (SSRF)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-04-23 - SSRF Vulnerability in User-Provided Image URLs
+**Vulnerability:** The application was vulnerable to Server-Side Request Forgery (SSRF). The `GooglePhotoUrl` parameter from the client in `Create.cshtml.cs` and `Edit.cshtml.cs` was passed directly to `HttpClient.GetAsync()` without any validation. An attacker could potentially use this to make the server send HTTP requests to arbitrary internal or external addresses.
+**Learning:** Never pass unvalidated user input directly into network request clients like `HttpClient`. Even if the UI attempts to constrain the input (e.g., Google Photos integration), an attacker can easily bypass client-side restrictions and submit malicious URLs directly to the backend endpoint.
+**Prevention:** Always strictly validate user-provided URLs. Ensure the scheme is `https://`, verify the URL is absolute, and enforce a strict allowlist of trusted hostnames (e.g., `*.googleusercontent.com`) before initiating any server-side HTTP requests. If validation fails, return a generic error message to avoid leaking internal information.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,14 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                (!uri.Host.EndsWith(".googleusercontent.com") && uri.Host != "googleusercontent.com"))
+            {
+                ModelState.AddModelError(string.Empty, "Invalid photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,14 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                (!uri.Host.EndsWith(".googleusercontent.com") && uri.Host != "googleusercontent.com"))
+            {
+                ModelState.AddModelError(string.Empty, "Invalid photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
- 🚨 Severity: CRITICAL
- 💡 Vulnerability: Server-Side Request Forgery (SSRF) was possible because `GooglePhotoUrl` from client was directly passed to `HttpClient.GetAsync()`.
- 🎯 Impact: An attacker could force the server to make unauthorized internal or external HTTP requests, potentially exposing internal services or performing actions on behalf of the server.
- 🔧 Fix: Validates that the URL uses HTTPS, is an absolute URI, and restricts the host to the trusted `googleusercontent.com` domain.
- ✅ Verification: Run `dotnet build` and `dotnet test`. Verified by checking that invalid photo URLs (e.g. non-HTTPS, arbitrary domains) now return a generic validation error without initiating network calls.

---
*PR created automatically by Jules for task [10458463493786614901](https://jules.google.com/task/10458463493786614901) started by @whwar9739*