### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF in Google Photos Integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-04-24 - SSRF Vulnerability in Google Photos Integration
+**Vulnerability:** The `Create.cshtml.cs` and `Edit.cshtml.cs` pages under `Pages/Whiskies` accepted an arbitrary, unsanitized `GooglePhotoUrl` via `[BindProperty]` and subsequently passed it to `HttpClient.GetAsync()`. This created a Server-Side Request Forgery (SSRF) vulnerability where an attacker could force the server to make HTTP requests to internal or unintended external systems.
+**Learning:** External user input, particularly URLs, should never be trusted and passed directly to an HTTP client. Doing so permits SSRF attacks.
+**Prevention:** Always validate external URLs using strict whitelists before issuing outbound requests. Ensure the URI scheme is HTTPS and the host matches the expected, trusted provider (e.g., `*.googleusercontent.com`).

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,14 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !uri.Host.EndsWith(".googleusercontent.com"))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL. Must be a valid googleusercontent.com HTTPS URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,14 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !uri.Host.EndsWith(".googleusercontent.com"))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL. Must be a valid googleusercontent.com HTTPS URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Server-Side Request Forgery (SSRF) was possible via the `GooglePhotoUrl` property in `Create.cshtml.cs` and `Edit.cshtml.cs`. The application accepted an arbitrary, unsanitized URL and subsequently passed it to `HttpClient.GetAsync()`.
🎯 **Impact:** An attacker could force the server to make HTTP requests to internal or unintended external systems.
🔧 **Fix:** Added input validation using `Uri.TryCreate` to ensure the URL is absolute, uses the HTTPS scheme, and ends with the trusted host `.googleusercontent.com` before issuing the outbound request. Added a model error if validation fails.
✅ **Verification:** Ran `dotnet test` to verify no regressions were introduced. Evaluated using the code review tool and determined to be safe and robust.

---
*PR created automatically by Jules for task [11785966031435767792](https://jules.google.com/task/11785966031435767792) started by @whwar9739*