### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photos Integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-04-26 - Server-Side Request Forgery (SSRF) in Google Photos Integration
+**Vulnerability:** The application took user-provided URLs (`GooglePhotoUrl`) and directly executed `HttpClient.GetAsync(GooglePhotoUrl)` without checking the scheme or host. This allowed an attacker to potentially access internal network resources or read internal files.
+**Learning:** External URLs provided via user input must always be validated before being fetched on the server-side to prevent SSRF attacks. Relying on client-side logic or hoping the user provides a valid Google Photos URL is insufficient.
+**Prevention:** Always validate that user-provided URLs use a secure scheme (`https`) and target an expected, trusted domain (e.g., `.googleusercontent.com`) before passing them to `HttpClient`.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,14 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !uri.Host.EndsWith(".googleusercontent.com", StringComparison.OrdinalIgnoreCase))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL. Must be a secure googleusercontent.com URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,14 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !uri.Host.EndsWith(".googleusercontent.com", StringComparison.OrdinalIgnoreCase))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL. Must be a secure googleusercontent.com URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
### 🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photos Integration

**🚨 Severity:** CRITICAL
**💡 Vulnerability:** The application took user-provided URLs (`GooglePhotoUrl`) and directly executed `HttpClient.GetAsync(GooglePhotoUrl)` without checking the scheme or host.
**🎯 Impact:** This allowed an attacker to potentially access internal network resources or read internal files through a Server-Side Request Forgery (SSRF) attack.
**🔧 Fix:** Added strict URI validation to ensure that any provided URL is absolute, uses the HTTPS scheme, and targets the `.googleusercontent.com` host before the application makes a request to it. Handled gracefully with ModelState errors.
**✅ Verification:** Verified with `dotnet test`.

Also added this critical learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [12130966426040680200](https://jules.google.com/task/12130966426040680200) started by @whwar9739*