### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Server-Side Request Forgery (SSRF) in Google Photos URL fetching

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2026-04-27 - Missing URL Validation Leading to SSRF Risk
+**Vulnerability:** GooglePhotoUrl parameter was used directly in HttpClient.GetAsync without validating the URI scheme or host, leading to a potential Server-Side Request Forgery (SSRF) vulnerability where an attacker could force the server to make requests to internal network resources.
+**Learning:** Always validate user-provided URLs before fetching them on the server side to ensure they point to expected external hosts and use secure protocols.
+**Prevention:** Use Uri.TryCreate to ensure absolute URIs, restrict the scheme to HTTPS, and validate that the host ends with the expected domain (e.g., .googleusercontent.com) before passing the URL to HttpClient.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,14 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var parsedUri) ||
+                parsedUri.Scheme != Uri.UriSchemeHttps ||
+                !parsedUri.Host.EndsWith(".googleusercontent.com", StringComparison.OrdinalIgnoreCase))
+            {
+                ModelState.AddModelError(string.Empty, "Invalid Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,14 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var parsedUri) ||
+                parsedUri.Scheme != Uri.UriSchemeHttps ||
+                !parsedUri.Host.EndsWith(".googleusercontent.com", StringComparison.OrdinalIgnoreCase))
+            {
+                ModelState.AddModelError(string.Empty, "Invalid Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: User-provided URLs for Google Photos integration were fetched directly using HttpClient.GetAsync without validation, allowing a potential Server-Side Request Forgery (SSRF) attack.
🎯 Impact: An attacker could force the server to make arbitrary internal HTTP requests.
🔧 Fix: Validated that the URI is absolute, uses the HTTPS scheme, and its host explicitly ends with `.googleusercontent.com` before initiating the request. The fix was applied to both `Create.cshtml.cs` and `Edit.cshtml.cs`.
✅ Verification: Ran `dotnet build` and `dotnet test` successfully to ensure normal operation logic is unaffected. Added finding to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [5861578362848337343](https://jules.google.com/task/5861578362848337343) started by @whwar9739*