### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in image import

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2025-02-27 - Server-Side Request Forgery (SSRF) in Image Import
+**Vulnerability:** The application allowed users to provide a `GooglePhotoUrl` that the server would fetch via `HttpClient.GetAsync()` without validating the URL scheme or host. This could be abused to make the server perform requests to internal networks or unapproved external domains.
+**Learning:** Accepting user-provided URLs for server-side fetching is dangerous unless strictly constrained to expected domains.
+**Prevention:** Always validate URLs using `Uri.TryCreate`, verify the scheme is HTTPS, and strictly enforce allowed hosts (e.g., `parsedUri.Host.EndsWith(".googleusercontent.com")`) before invoking HTTP clients.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,14 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var parsedUri) ||
+                parsedUri.Scheme != Uri.UriSchemeHttps ||
+                !parsedUri.Host.EndsWith(".googleusercontent.com", StringComparison.OrdinalIgnoreCase))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,14 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var parsedUri) ||
+                parsedUri.Scheme != Uri.UriSchemeHttps ||
+                !parsedUri.Host.EndsWith(".googleusercontent.com", StringComparison.OrdinalIgnoreCase))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Server-Side Request Forgery (SSRF). The application allowed importing images from a user-provided `GooglePhotoUrl` via `HttpClient.GetAsync()` without any validation of the URI scheme or destination host.
🎯 **Impact:** An attacker could provide a malicious URL, forcing the application server to make requests to internal network services, local loopback addresses, or unapproved external domains, potentially exposing sensitive internal data or being used as a proxy for external attacks.
🔧 **Fix:** Added validation in `Create.cshtml.cs` and `Edit.cshtml.cs` to ensure the provided URL is a valid absolute URI, uses the HTTPS scheme, and targets the trusted `googleusercontent.com` domain before initiating the HTTP request. If validation fails, an error is added to `ModelState` and the user is redirected back to the form.
✅ **Verification:** Attempting to submit a URL with `http://` or pointing to a different domain like `https://malicious.com/image.jpg` will result in a model error "Invalid Google Photo URL." and no HTTP request will be made. Standard Google Photos URLs will continue to work as expected. All unit tests have been successfully run and pass.

Also updated `.jules/sentinel.md` with the new learning about URL validation.

---
*PR created automatically by Jules for task [6047509899065879221](https://jules.google.com/task/6047509899065879221) started by @whwar9739*