### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF and Path Traversal in image uploads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,12 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2026-04-30 - [SSRF and Path Traversal in Image Uploads]
+**Vulnerability:**
+1. Server-Side Request Forgery (SSRF) allowed the application to fetch from arbitrary URLs using `HttpClient.GetAsync(GooglePhotoUrl)` without checking the domain.
+2. Path Traversal vulnerability when handling image uploads directly concatenating `ImageUpload.FileName` with a Guid, allowing directory traversal with characters like `../`.
+**Learning:** External user inputs used in sensitive contexts like file downloads (SSRF) and file saves (Path Traversal) must be strictly validated.
+**Prevention:**
+1. Use `Uri.TryCreate` to ensure the URL is absolute and uses HTTPS, and strictly match the host to a known-safe domain (e.g. `.googleusercontent.com`).
+2. Only retain the extension using `Path.GetExtension(ImageUpload.FileName)` when constructing safe filenames.

--- a/WhiskeyTracker.Tests/WhiskiesTests.cs
+++ b/WhiskeyTracker.Tests/WhiskiesTests.cs
@@ -126,7 +126,7 @@ public class WhiskiesTests : TestBase
         Assert.IsType<RedirectToPageResult>(result);
         var whiskey = await context.Whiskies.FirstAsync();
         Assert.Equal("Test Whiskey", whiskey.Name);
-        Assert.Contains("test.jpg", whiskey.ImageFileName); // Confirms filename was generated
+        Assert.True(whiskey.ImageFileName.EndsWith(".jpg")); // Confirms filename was generated
     }
 
     [Fact]
@@ -477,7 +477,7 @@ public class WhiskiesTests : TestBase
         Assert.NotNull(updatedWhiskey);
         Assert.NotNull(updatedWhiskey.ImageFileName);
         Assert.NotEqual(oldFileName, updatedWhiskey.ImageFileName);
-        Assert.Contains(newFileName, updatedWhiskey.ImageFileName);
+        Assert.True(updatedWhiskey.ImageFileName.EndsWith(".jpg"));
         Assert.False(File.Exists(oldFilePath));
         Assert.True(File.Exists(Path.Combine(tempPath, "images", updatedWhiskey.ImageFileName)));
 

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,14 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host == "googleusercontent.com"))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid or unauthorized image URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
@@ -65,7 +73,7 @@ public class CreateModel : PageModel
         }
         else if (ImageUpload != null)
         {
-            var uniqueFileName = Guid.NewGuid().ToString() + "_" + ImageUpload.FileName;
+            var uniqueFileName = Guid.NewGuid().ToString() + Path.GetExtension(ImageUpload.FileName);
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
 
             if (!Directory.Exists(uploadsFolder))

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,14 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host == "googleusercontent.com"))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid or unauthorized image URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
@@ -86,7 +94,7 @@ public class EditModel : PageModel
         }
         else if (ImageUpload != null)
         {
-            var uniqueFileName = Guid.NewGuid().ToString() + "_" + ImageUpload.FileName;
+            var uniqueFileName = Guid.NewGuid().ToString() + Path.GetExtension(ImageUpload.FileName);
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: 
1. Server-Side Request Forgery (SSRF) allowed the application to fetch from arbitrary URLs using `HttpClient.GetAsync(GooglePhotoUrl)` without checking the domain.
2. Path Traversal vulnerability when handling image uploads directly concatenating `ImageUpload.FileName` with a Guid, allowing directory traversal with characters like `../`.
🎯 Impact: Attackers could potentially read internal files, make requests on behalf of the server to internal networks, or overwrite critical files.
🔧 Fix: 
1. Added `Uri.TryCreate` validation to ensure the URL is absolute and uses HTTPS, and strictly matched the host to a known-safe domain (e.g. `.googleusercontent.com`) before making the HTTP request.
2. Modified file upload handling to only retain the extension using `Path.GetExtension(ImageUpload.FileName)` when constructing safe filenames.
✅ Verification: Ran unit tests to ensure image upload functionality still works correctly with the security improvements in place. Verified journal entry addition.

---
*PR created automatically by Jules for task [18078428317297400895](https://jules.google.com/task/18078428317297400895) started by @whwar9739*