### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF and Token Leak in Google Photos integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-04-16 - SSRF and Token Leak in Google Photos Integration
+**Vulnerability:** The application took an untrusted URL (`GooglePhotoUrl`) provided by the client and immediately performed a GET request to that URL, using the `GooglePhotoToken` as a Bearer token. If an attacker provided a URL pointing to a server they control, they could intercept the OAuth token. This could also be used to scan internal network resources (SSRF).
+**Learning:** Any user-provided URL fetched by the server must be strictly validated to ensure it points to the expected domain and uses a secure protocol.
+**Prevention:** Always validate `Uri.Scheme` is HTTPS and `Uri.Host` ends with the expected trusted domain(s) (e.g., `.googleusercontent.com` or `.googleapis.com`) before making outbound HTTP requests with sensitive tokens.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,14 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var parsedUri) ||
+                parsedUri.Scheme != Uri.UriSchemeHttps ||
+                !(parsedUri.Host.EndsWith(".googleusercontent.com") || parsedUri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL. Must be a secure connection to Google services.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
@@ -57,7 +65,7 @@ public class CreateModel : PageModel
                 var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
                 var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
-                
+
                 var filePath = Path.Combine(uploadsFolder, uniqueFileName);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
                 NewWhiskey.ImageFileName = uniqueFileName;
@@ -74,7 +82,7 @@ public class CreateModel : PageModel
             }
 
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-            
+
             using (var fileStream = new FileStream(filePath, FileMode.Create))
             {
                 await ImageUpload.CopyToAsync(fileStream);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,14 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var parsedUri) ||
+                parsedUri.Scheme != Uri.UriSchemeHttps ||
+                !(parsedUri.Host.EndsWith(".googleusercontent.com") || parsedUri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL. Must be a secure connection to Google services.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
@@ -74,7 +82,7 @@ public class EditModel : PageModel
 
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
-                
+
                 if (!string.IsNullOrEmpty(Whiskey.ImageFileName))
                 {
                     var oldPath = Path.Combine(uploadsFolder, Whiskey.ImageFileName);


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The application took an untrusted URL (`GooglePhotoUrl`) provided by the client and immediately performed a GET request to that URL, using the `GooglePhotoToken` as a Bearer token. This allowed for an SSRF and Token Leak vulnerability, potentially exfiltrating sensitive tokens or scanning internal network resources.
🎯 **Impact:** Exfiltration of OAuth tokens, possible unauthorized access, and SSRF.
🔧 **Fix:** Added strict URL validation ensuring that the protocol is HTTPS and the target host belongs to trusted Google domains (`.googleusercontent.com` or `.googleapis.com`).
✅ **Verification:** Verified by checking unit tests pass correctly. Tested validation logic with `Uri` structure and confirmed `dotnet test` returns cleanly. Also recorded learning into `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [16822180354762158041](https://jules.google.com/task/16822180354762158041) started by @whwar9739*