### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in Google Photos integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2026-05-02 - SSRF Vulnerability in Google Photos Integration
+**Vulnerability:** The application accepted arbitrary, user-supplied URLs for `GooglePhotoUrl` during whiskey creation and editing. It passed these unchecked to `HttpClient.GetAsync()`, allowing potential Server-Side Request Forgery (SSRF) against internal or unexpected external hosts.
+**Learning:** Accepting user input to fetch resources requires explicit validation to ensure requests only hit expected, safe endpoints.
+**Prevention:** Strictly validate that any fetched URI uses HTTPS and targets a trusted host (e.g., `.googleusercontent.com` or `.googleapis.com`) before invoking HTTP requests.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -7,7 +7,7 @@ namespace WhiskeyTracker.Web.Pages.Whiskies;
 
 
 
-[Authorize]
+[Authorize(Roles = "Admin")]
 public class CreateModel : PageModel
 {
     private readonly AppDbContext _context;
@@ -48,6 +48,14 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL. Only googleusercontent.com or googleapis.com domains are permitted.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -9,7 +9,7 @@ namespace WhiskeyTracker.Web.Pages.Whiskies;
 
 
 
-[Authorize]
+[Authorize(Roles = "Admin")]
 public class EditModel : PageModel
 {
     private readonly AppDbContext _context;
@@ -62,6 +62,14 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL. Only googleusercontent.com or googleapis.com domains are permitted.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unvalidated user input was used to construct an HTTP request via `HttpClient` for downloading images using `GooglePhotoUrl` in `Create.cshtml.cs` and `Edit.cshtml.cs`.
🎯 **Impact:** Server-Side Request Forgery (SSRF) could be exploited to scan internal networks, read internal configuration, or send requests from the application's context.
🔧 **Fix:** Added strict URL validation using the `Uri` class. Now ensuring `Uri.UriSchemeHttps` and validating that the target host ends with trusted Google photo domains (`.googleusercontent.com` or `.googleapis.com`). Also updated the class-level authorization from `[Authorize]` to `[Authorize(Roles = "Admin")]` because these functions update global master entities and were not covered by folder conventions.
✅ **Verification:** Attempting to submit a URL like `http://internal-metadata-service` will trigger a validation error without fetching the resource. The application compiles correctly and all unit tests passed with `dotnet test`.

---
*PR created automatically by Jules for task [2925164713337820069](https://jules.google.com/task/2925164713337820069) started by @whwar9739*