### PR TITLE
fix: prevent SSRF in image upload

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-04 - Server-Side Request Forgery (SSRF) in Image Upload
+**Vulnerability:** The `Create.cshtml.cs` and `Edit.cshtml.cs` page models fetched images from a user-provided `GooglePhotoUrl` using `HttpClient.GetAsync()` without validating the URL. This allowed an attacker to potentially supply arbitrary URLs (e.g., internal network addresses or `file://` URIs) resulting in a Server-Side Request Forgery (SSRF) vulnerability.
+**Learning:** Always validate user-supplied URLs before making outbound HTTP requests on behalf of the user. Ensure the URL scheme is HTTPS and restrict requests to known, trusted hosts.
+**Prevention:** Implement strict URI validation using `Uri.TryCreate` to ensure the URL is absolute, uses the HTTPS scheme, and its host ends with an approved domain (e.g., `.googleusercontent.com` or `.googleapis.com`).

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,14 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,14 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Server-Side Request Forgery (SSRF)

🚨 Severity: CRITICAL
💡 Vulnerability: `Create.cshtml.cs` and `Edit.cshtml.cs` allowed fetching images from user-provided URLs using `HttpClient.GetAsync()` without validation.
🎯 Impact: Attackers could potentially supply arbitrary URLs (e.g., internal network addresses) resulting in Server-Side Request Forgery (SSRF) and potential exfiltration of the `GooglePhotoToken`.
🔧 Fix: Implemented strict URI validation using `Uri.TryCreate` to ensure the URL is absolute, uses the HTTPS scheme, and its host ends with an approved domain (`.googleusercontent.com` or `.googleapis.com`).
✅ Verification: Ran `dotnet test` successfully and verified that invalid URLs correctly result in a `ModelState` error.

---
*PR created automatically by Jules for task [3469463106848368689](https://jules.google.com/task/3469463106848368689) started by @whwar9739*