### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Server-Side Request Forgery (SSRF) vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+## 2024-05-05 - Missing URI Validation in Image Fetching (SSRF)
+**Vulnerability:** The application accepted user-provided URLs for fetching images (`GooglePhotoUrl`) without validating that the URI uses HTTPS or points to a trusted domain, potentially allowing Server-Side Request Forgery (SSRF) attacks.
+**Learning:** Any endpoint that fetches resources from a user-provided URL must strictly validate the URI scheme and host before making the HTTP request to prevent the server from accessing internal or malicious external resources.
+**Prevention:** Implement strict `Uri.TryCreate` validation to ensure the URL uses `Uri.UriSchemeHttps` and the `Uri.Host` ends with a trusted domain (e.g., `.googleusercontent.com` or `.googleapis.com`) before invoking `HttpClient.GetAsync()`.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,14 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL. Only trusted HTTPS URLs are allowed.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,14 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL. Only trusted HTTPS URLs are allowed.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
🚨 Severity: CRITICAL\n💡 Vulnerability: The application accepted user-provided URLs for fetching images (`GooglePhotoUrl`) without validating that the URI uses HTTPS or points to a trusted domain, potentially allowing Server-Side Request Forgery (SSRF) attacks.\n🎯 Impact: An attacker could potentially coerce the server into making arbitrary HTTP requests to internal networks or malicious external endpoints.\n🔧 Fix: Implemented strict `Uri.TryCreate` validation to ensure the URL uses `Uri.UriSchemeHttps` and the `Uri.Host` ends with a trusted domain (e.g., `.googleusercontent.com` or `.googleapis.com`) before invoking `HttpClient.GetAsync()` in both `Create.cshtml.cs` and `Edit.cshtml.cs`.\n✅ Verification: The code compiles successfully and all unit tests pass. I also updated the `.jules/sentinel.md` journal with this critical security learning.

---
*PR created automatically by Jules for task [5580377504244630344](https://jules.google.com/task/5580377504244630344) started by @whwar9739*