### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photos Integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-06 - SSRF Vulnerability in Google Photos Integration
+**Vulnerability:** The application was vulnerable to Server-Side Request Forgery (SSRF) during the Google Photos import process (`Create.cshtml.cs` and `Edit.cshtml.cs`). The `GooglePhotoUrl` parameter was passed directly to `HttpClient.GetAsync()` without any validation, allowing an attacker to force the server to make requests to internal network resources or unauthorized external domains.
+**Learning:** Never trust user-provided URLs or assume they only point to intended external services, even if they are populated by a trusted client-side script. The backend must always perform its own validation.
+**Prevention:** Always strictly validate user-provided URIs before passing them to an HTTP client. Ensure the URI is absolute, uses the HTTPS scheme, and targets a trusted, whitelisted host (e.g., `.googleusercontent.com` or `.googleapis.com`).

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,19 +48,29 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
-            if (response.IsSuccessStatusCode)
+            if (Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) &&
+                uri.Scheme == Uri.UriSchemeHttps &&
+                (uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
             {
-                var imageBytes = await response.Content.ReadAsByteArrayAsync();
-                var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
-                var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
-                if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
-                
-                var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-                await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
-                NewWhiskey.ImageFileName = uniqueFileName;
+                using var httpClient = new HttpClient();
+                httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
+                var response = await httpClient.GetAsync(GooglePhotoUrl);
+                if (response.IsSuccessStatusCode)
+                {
+                    var imageBytes = await response.Content.ReadAsByteArrayAsync();
+                    var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
+                    var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
+                    if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
+
+                    var filePath = Path.Combine(uploadsFolder, uniqueFileName);
+                    await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
+                    NewWhiskey.ImageFileName = uniqueFileName;
+                }
+            }
+            else
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL.");
+                return Page();
             }
         }
         else if (ImageUpload != null)

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,26 +62,36 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
-            if (response.IsSuccessStatusCode)
+            if (Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) &&
+                uri.Scheme == Uri.UriSchemeHttps &&
+                (uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
             {
-                var imageBytes = await response.Content.ReadAsByteArrayAsync();
-                var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
-                var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
-                var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-
-                if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
-                await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
-                
-                if (!string.IsNullOrEmpty(Whiskey.ImageFileName))
+                using var httpClient = new HttpClient();
+                httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
+                var response = await httpClient.GetAsync(GooglePhotoUrl);
+                if (response.IsSuccessStatusCode)
                 {
-                    var oldPath = Path.Combine(uploadsFolder, Whiskey.ImageFileName);
-                    if (System.IO.File.Exists(oldPath)) System.IO.File.Delete(oldPath);
-                }
+                    var imageBytes = await response.Content.ReadAsByteArrayAsync();
+                    var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
+                    var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
+                    var filePath = Path.Combine(uploadsFolder, uniqueFileName);
 
-                Whiskey.ImageFileName = uniqueFileName;
+                    if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
+                    await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
+
+                    if (!string.IsNullOrEmpty(Whiskey.ImageFileName))
+                    {
+                        var oldPath = Path.Combine(uploadsFolder, Whiskey.ImageFileName);
+                        if (System.IO.File.Exists(oldPath)) System.IO.File.Delete(oldPath);
+                    }
+
+                    Whiskey.ImageFileName = uniqueFileName;
+                }
+            }
+            else
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL.");
+                return Page();
             }
         }
         else if (ImageUpload != null)


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The application was vulnerable to SSRF during the Google Photos import process (`Create.cshtml.cs` and `Edit.cshtml.cs`). The `GooglePhotoUrl` parameter was passed directly to `HttpClient.GetAsync()` without any backend validation.
🎯 **Impact**: An attacker could manipulate the `GooglePhotoUrl` payload to force the server to make unauthorized GET requests, potentially scanning internal networks, accessing cloud metadata APIs, or interacting with unintended external services.
🔧 **Fix**: Added inline, strict validation for user-provided URIs before passing them to the HTTP client. The validation ensures the URI is valid, absolute, uses HTTPS, and its host explicitly ends with either `.googleusercontent.com` or `.googleapis.com`. If validation fails, the application safely halts the photo import and alerts the user by adding an error to the `ModelState`.
✅ **Verification**: Local verification confirms that modifying the `GooglePhotoUrl` to a non-whitelisted domain successfully halts the fetch operation. The project successfully builds, and all 81 automated tests pass without regressions. A journal entry was added to `.jules/sentinel.md` documenting the learning.

---
*PR created automatically by Jules for task [7383302770536075840](https://jules.google.com/task/7383302770536075840) started by @whwar9739*