### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix URL validation issue

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2026-05-07 - Server-Side Request Forgery (SSRF) via Google Photo Fetching
+**Vulnerability:** The application was fetching Google photo images based on user-provided `GooglePhotoUrl` without validating the host or scheme. This could allow an attacker to make the server issue HTTP GET requests to internal networks or unapproved external URLs, resulting in a Server-Side Request Forgery (SSRF) vulnerability.
+**Learning:** Whenever an application makes outbound HTTP requests based on user input, it's critical to strictly validate the destination URL.
+**Prevention:** Use `Uri.TryCreate` to ensure the URL is valid, verify the scheme is strictly `https`, and check that the host matches a specific, trusted allowlist (e.g., `.googleusercontent.com` and `.googleapis.com`) before making the request.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,14 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uriResult)
+                || uriResult.Scheme != Uri.UriSchemeHttps
+                || (!uriResult.Host.EndsWith(".googleusercontent.com") && !uriResult.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid or untrusted Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,14 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uriResult)
+                || uriResult.Scheme != Uri.UriSchemeHttps
+                || (!uriResult.Host.EndsWith(".googleusercontent.com") && !uriResult.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid or untrusted Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: User-provided URLs were not being sufficiently validated before making outbound HTTP requests, introducing a potential vulnerability.
🎯 Impact: This could potentially allow unauthorized requests to be made from the server to internal networks or unapproved external URLs.
🔧 Fix: Implemented strict URL validation using `Uri.TryCreate` to ensure the URL is valid, verify the scheme is strictly `https`, and check that the host matches a specific, trusted allowlist (`.googleusercontent.com` and `.googleapis.com`) before making any outbound request.
✅ Verification: Ran unit tests and manually verified that the code no longer allows the request if an untrusted URL is passed. The user will receive a `ModelState` error in this scenario. Added an entry to `.jules/sentinel.md` to document the finding and prevention steps.

---
*PR created automatically by Jules for task [9459178339453158003](https://jules.google.com/task/9459178339453158003) started by @whwar9739*