### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photo URL Fetch

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-08 - SSRF Vulnerability via Untrusted Image URL
+**Vulnerability:** A Server-Side Request Forgery (SSRF) vulnerability existed where user-provided Google Photo URLs (`GooglePhotoUrl`) were fetched via `HttpClient.GetAsync()` without validation. This could allow attackers to scan internal networks or access sensitive metadata services from the server.
+**Learning:** Even expected features like pulling an image from an external service must rigorously validate the requested URI's scheme and host to prevent SSRF attacks.
+**Prevention:** Always parse untrusted URLs using `Uri.TryCreate` and strictly validate that the URI uses HTTPS and the host matches an expected allowlist (e.g., `.googleusercontent.com` or `.googleapis.com`) before invoking any HTTP requests.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,14 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                (!uri.Host.EndsWith(".googleusercontent.com") && !uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid or untrusted photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,14 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                (!uri.Host.EndsWith(".googleusercontent.com") && !uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid or untrusted photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A Server-Side Request Forgery (SSRF) vulnerability existed in the image fetch feature where `GooglePhotoUrl` user input was directly passed to `HttpClient.GetAsync()` without any validation in `Create.cshtml.cs` and `Edit.cshtml.cs`.
🎯 **Impact:** Attackers could exploit this to scan internal network infrastructure or access metadata services using the server.
🔧 **Fix:** Added rigorous URL validation using `Uri.TryCreate` to ensure the URI uses `UriSchemeHttps` and the host matches an expected whitelist (`.googleusercontent.com` or `.googleapis.com`) before making the HTTP request.
✅ **Verification:** Run `dotnet test` to confirm functionality remains intact and no regressions occurred.

---
*PR created automatically by Jules for task [14176184930682980087](https://jules.google.com/task/14176184930682980087) started by @whwar9739*