### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF and Path Traversal in file uploads

### DIFF
--- a/WhiskeyTracker.Tests/WhiskiesTests.cs
+++ b/WhiskeyTracker.Tests/WhiskiesTests.cs
@@ -126,7 +126,7 @@ public class WhiskiesTests : TestBase
         Assert.IsType<RedirectToPageResult>(result);
         var whiskey = await context.Whiskies.FirstAsync();
         Assert.Equal("Test Whiskey", whiskey.Name);
-        Assert.Contains("test.jpg", whiskey.ImageFileName); // Confirms filename was generated
+        Assert.EndsWith(".jpg", whiskey.ImageFileName); // Confirms filename was generated
     }
 
     [Fact]
@@ -477,7 +477,7 @@ public class WhiskiesTests : TestBase
         Assert.NotNull(updatedWhiskey);
         Assert.NotNull(updatedWhiskey.ImageFileName);
         Assert.NotEqual(oldFileName, updatedWhiskey.ImageFileName);
-        Assert.Contains(newFileName, updatedWhiskey.ImageFileName);
+        Assert.EndsWith(".jpg", updatedWhiskey.ImageFileName);
         Assert.False(File.Exists(oldFilePath));
         Assert.True(File.Exists(Path.Combine(tempPath, "images", updatedWhiskey.ImageFileName)));
 

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,7 +48,11 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            if (Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uriResult) &&
+                uriResult.Scheme == Uri.UriSchemeHttps &&
+                (uriResult.Host.EndsWith(".googleusercontent.com") || uriResult.Host.EndsWith(".googleapis.com")))
+            {
+                using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)
@@ -63,9 +67,11 @@ public class CreateModel : PageModel
                 NewWhiskey.ImageFileName = uniqueFileName;
             }
         }
+        }
         else if (ImageUpload != null)
         {
-            var uniqueFileName = Guid.NewGuid().ToString() + "_" + ImageUpload.FileName;
+            var extension = Path.GetExtension(ImageUpload.FileName);
+            var uniqueFileName = Guid.NewGuid().ToString() + extension;
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
 
             if (!Directory.Exists(uploadsFolder))

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,7 +62,11 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            if (Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uriResult) &&
+                uriResult.Scheme == Uri.UriSchemeHttps &&
+                (uriResult.Host.EndsWith(".googleusercontent.com") || uriResult.Host.EndsWith(".googleapis.com")))
+            {
+                using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)
@@ -84,9 +88,11 @@ public class EditModel : PageModel
                 Whiskey.ImageFileName = uniqueFileName;
             }
         }
+        }
         else if (ImageUpload != null)
         {
-            var uniqueFileName = Guid.NewGuid().ToString() + "_" + ImageUpload.FileName;
+            var extension = Path.GetExtension(ImageUpload.FileName);
+            var uniqueFileName = Guid.NewGuid().ToString() + extension;
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
 


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability:
1. SSRF in Google Photos Integration: `GooglePhotoUrl` was fetched without validating the schema (HTTPS) or host, potentially allowing an attacker to coerce the server to fetch internal resources or arbitrary external content.
2. Path Traversal in Image Uploads: The original filename provided during `ImageUpload` was appended to a GUID without sanitization. If the filename contained directory traversal characters, it could result in files being written outside the intended directory.

🎯 Impact:
1. SSRF could lead to information disclosure or lateral movement within the hosting network.
2. Path Traversal could lead to arbitrary file write, potentially leading to Remote Code Execution (RCE) if an executable file was written to a web-accessible directory.

🔧 Fix:
1. Validated `GooglePhotoUrl` using `Uri.TryCreate` to ensure it is an absolute URI, uses the `https` scheme, and targets either `.googleusercontent.com` or `.googleapis.com`.
2. Changed `ImageUpload` filename logic to discard the original filename completely, only preserving its extension via `Path.GetExtension()`.

✅ Verification:
1. Unit tests pass successfully.
2. The logic safely mitigates both vulnerabilities.

---
*PR created automatically by Jules for task [13430473834670355625](https://jules.google.com/task/13430473834670355625) started by @whwar9739*