### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Server-Side Request Forgery (SSRF) in Image Uploads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2025-05-24 - [SSRF Mitigation in Image Uploads]
+**Vulnerability:** A critical Server-Side Request Forgery (SSRF) risk existed because user-controlled `GooglePhotoUrl` inputs were passed directly to `HttpClient.GetAsync()` without domain validation in `Create.cshtml.cs` and `Edit.cshtml.cs`.
+**Learning:** External integrations fetching resources via URLs supplied by users must have strictly validated endpoints.
+**Prevention:** Apply whitelist-based URI validation, enforcing HTTPS and trusted domains, prior to invoking outbound HTTP calls.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,16 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            // Security: Prevent Server-Side Request Forgery (SSRF)
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                // Invalid URL format, scheme, or domain
+                ModelState.AddModelError(nameof(GooglePhotoUrl), "Invalid image source URL. Must be a trusted Google domain.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,16 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            // Security: Prevent Server-Side Request Forgery (SSRF)
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                // Invalid URL format, scheme, or domain
+                ModelState.AddModelError(nameof(GooglePhotoUrl), "Invalid image source URL. Must be a trusted Google domain.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: User-controlled `GooglePhotoUrl` string was passed directly to `HttpClient.GetAsync()` without domain validation, creating a Server-Side Request Forgery (SSRF) risk.
🎯 Impact: Attackers could potentially exploit this to make the server send outbound requests to internal endpoints or unapproved external domains.
🔧 Fix: Added strict URL validation ensuring HTTPS scheme and trusted Google subdomains prior to processing image requests.
✅ Verification: `dotnet test` successfully validates logic, and builds compile. 

---
*PR created automatically by Jules for task [6838186802677922255](https://jules.google.com/task/6838186802677922255) started by @whwar9739*