### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Server-Side Request Forgery in Photo Upload

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-12 - SSRF Vulnerability in Google Photos Integration
+**Vulnerability:** The application accepted a user-provided URL (`GooglePhotoUrl`) and immediately issued a server-side `HttpClient.GetAsync()` request to it in both `Create.cshtml.cs` and `Edit.cshtml.cs` without validating the host or scheme. This could allow an attacker to make the server fetch arbitrary internal network resources or external malicious payloads (Server-Side Request Forgery).
+**Learning:** Even when a feature is intended to integrate with a specific third-party service (like Google Photos API), user-controlled URLs must strictly enforce domain allowlisting.
+**Prevention:** Always validate that external URIs strictly use HTTPS and point only to trusted, expected host domains (e.g., `.googleusercontent.com`, `.googleapis.com`) before making outbound HTTP requests from the server.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,15 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            // Security: Prevent SSRF by validating the URL is HTTPS and points to a trusted Google host
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                (!uri.Host.EndsWith(".googleusercontent.com") && !uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,15 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            // Security: Prevent SSRF by validating the URL is HTTPS and points to a trusted Google host
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                (!uri.Host.EndsWith(".googleusercontent.com") && !uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Server-Side Request Forgery (SSRF) was possible because `Create.cshtml.cs` and `Edit.cshtml.cs` passed a user-provided URL (`GooglePhotoUrl`) directly into `HttpClient.GetAsync()` without validating the scheme or host domain.
🎯 **Impact:** An attacker could cause the server to issue HTTP GET requests to arbitrary internal network resources or external domains, potentially exposing internal services or facilitating further attacks.
🔧 **Fix:** Added validation to ensure the URL strictly uses HTTPS and that the host domain matches expected Google hosts (`.googleusercontent.com` or `.googleapis.com`). Invalid URLs are rejected with a `ModelState` error. Also updated `.jules/sentinel.md` with the critical learning.
✅ **Verification:** Ran automated unit tests via `dotnet test` to ensure existing functionality remains unaffected.

---
*PR created automatically by Jules for task [16995869277973032108](https://jules.google.com/task/16995869277973032108) started by @whwar9739*