### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in Google Photos integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-24 - SSRF in Google Photos Integration
+**Vulnerability:** Server-Side Request Forgery (SSRF) was possible because `HttpClient.GetAsync()` in `Create.cshtml.cs` and `Edit.cshtml.cs` fetched resources from user-provided URLs (`GooglePhotoUrl`) without validating the host or scheme. An attacker could potentially supply internal network addresses or malicious external URLs.
+**Learning:** Whenever fetching remote resources based on user input, strictly validate the URL scheme (e.g., HTTPS) and allowlist the target hosts. The codebase memory specifically instructs to trust `.googleusercontent.com` and `.googleapis.com` for this integration.
+**Prevention:** Always parse the URL using `Uri.TryCreate()` with `UriKind.Absolute` and check `uriResult.Scheme` and `uriResult.Host` before making outbound HTTP requests.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,15 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            // Validate URL to prevent SSRF
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uriResult) ||
+                uriResult.Scheme != Uri.UriSchemeHttps ||
+                !(uriResult.Host.EndsWith(".googleusercontent.com") || uriResult.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError(string.Empty, "Invalid image URL provided.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,15 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            // Validate URL to prevent SSRF
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uriResult) ||
+                uriResult.Scheme != Uri.UriSchemeHttps ||
+                !(uriResult.Host.EndsWith(".googleusercontent.com") || uriResult.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError(string.Empty, "Invalid image URL provided.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Server-Side Request Forgery (SSRF) via `HttpClient.GetAsync()` without host validation in `Create.cshtml.cs` and `Edit.cshtml.cs`.
🎯 Impact: An attacker could supply internal or malicious URLs to cause the server to perform unauthorized HTTP requests.
🔧 Fix: Parsed the URL using `Uri.TryCreate` with `UriKind.Absolute` and validated that the scheme is HTTPS and the host ends with `.googleusercontent.com` or `.googleapis.com`.
✅ Verification: Ran `dotnet test` successfully, tests pass. Checked code visually.

---
*PR created automatically by Jules for task [18014900210838269272](https://jules.google.com/task/18014900210838269272) started by @whwar9739*