### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF and Path Traversal in whiskey uploads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-15 - SSRF and Path Traversal in Whiskey Uploads
+**Vulnerability:** The application was fetching images from a user-provided URL (`GooglePhotoUrl`) without validating the scheme or host, leading to a Server-Side Request Forgery (SSRF) vulnerability. Additionally, file uploads used the original `ImageUpload.FileName` directly in the generated filename, presenting a Path Traversal vulnerability risk.
+**Learning:** Always explicitly validate the scheme (HTTPS) and allowed hosts for user-provided URLs before making outward HTTP requests. For file uploads, generate a strictly controlled unique filename (e.g., via GUID) and only append the safely extracted extension (`Path.GetExtension()`).
+**Prevention:** Use `Uri.TryCreate` with absolute URI kind to restrict URLs to expected hostnames (like `.googleusercontent.com`). Never trust user-provided filenames; always generate new random identifiers on the server.

--- a/WhiskeyTracker.Tests/WhiskiesTests.cs
+++ b/WhiskeyTracker.Tests/WhiskiesTests.cs
@@ -126,7 +126,7 @@ public class WhiskiesTests : TestBase
         Assert.IsType<RedirectToPageResult>(result);
         var whiskey = await context.Whiskies.FirstAsync();
         Assert.Equal("Test Whiskey", whiskey.Name);
-        Assert.Contains("test.jpg", whiskey.ImageFileName); // Confirms filename was generated
+        Assert.EndsWith(".jpg", whiskey.ImageFileName); // Confirms filename was generated
     }
 
     [Fact]
@@ -477,7 +477,7 @@ public class WhiskiesTests : TestBase
         Assert.NotNull(updatedWhiskey);
         Assert.NotNull(updatedWhiskey.ImageFileName);
         Assert.NotEqual(oldFileName, updatedWhiskey.ImageFileName);
-        Assert.Contains(newFileName, updatedWhiskey.ImageFileName);
+        Assert.EndsWith(".jpg", updatedWhiskey.ImageFileName);
         Assert.False(File.Exists(oldFilePath));
         Assert.True(File.Exists(Path.Combine(tempPath, "images", updatedWhiskey.ImageFileName)));
 

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,13 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid or untrusted URL.");
+                return Page();
+            }
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
@@ -65,7 +72,7 @@ public class CreateModel : PageModel
         }
         else if (ImageUpload != null)
         {
-            var uniqueFileName = Guid.NewGuid().ToString() + "_" + ImageUpload.FileName;
+            var uniqueFileName = Guid.NewGuid().ToString() + Path.GetExtension(ImageUpload.FileName);
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
 
             if (!Directory.Exists(uploadsFolder))

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,13 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid or untrusted URL.");
+                return Page();
+            }
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
@@ -86,7 +93,7 @@ public class EditModel : PageModel
         }
         else if (ImageUpload != null)
         {
-            var uniqueFileName = Guid.NewGuid().ToString() + "_" + ImageUpload.FileName;
+            var uniqueFileName = Guid.NewGuid().ToString() + Path.GetExtension(ImageUpload.FileName);
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
 


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix SSRF and Path Traversal vulnerabilities

🚨 Severity: HIGH
💡 Vulnerability: The application was fetching images from a user-provided URL (`GooglePhotoUrl`) without validating the scheme or host, leading to a Server-Side Request Forgery (SSRF) vulnerability. Additionally, file uploads used the original `ImageUpload.FileName` directly in the generated filename, presenting a Path Traversal vulnerability risk.
🎯 Impact: An attacker could perform internal port scanning or network probing (SSRF), or potentially write files outside the intended uploads directory (Path Traversal).
🔧 Fix:
- Added `Uri.TryCreate` validation to ensure `GooglePhotoUrl` uses HTTPS and has a trusted host (`.googleusercontent.com` or `.googleapis.com`).
- Modified file upload logic to only append the safely extracted extension (`Path.GetExtension()`) to a newly generated GUID, ignoring the rest of the original filename.
- Updated `WhiskeyTracker.Tests` to assert the new filename format.
- Documented findings in `.jules/sentinel.md`.
✅ Verification: Ensure the application builds (`dotnet build WhiskeyTracker.sln`) and tests pass (`dotnet test WhiskeyTracker.sln`). Try uploading an image via the local URL or UI; verify it generates a GUID-based name. Attempting an invalid URL like `http://internal-ip` should fail validation.

---
*PR created automatically by Jules for task [7641881150277950124](https://jules.google.com/task/7641881150277950124) started by @whwar9739*