### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photos Integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-17 - SSRF Vulnerability in Google Photos Integration
+**Vulnerability:** The application was vulnerable to Server-Side Request Forgery (SSRF) because it blindly accepted and fetched user-provided URLs (`GooglePhotoUrl`) in `Create.cshtml.cs` and `Edit.cshtml.cs` using `HttpClient.GetAsync()`. A malicious user could provide internal network URLs or malicious external URLs.
+**Learning:** Never trust user-provided URLs for server-side fetching. Always validate the scheme, host, and path before initiating an outbound request.
+**Prevention:** Implement strict URI validation using `Uri.TryCreate` with `UriKind.Absolute` and enforce an allowlist of trusted hosts (e.g., `.googleusercontent.com`, `.googleapis.com`) and require HTTPS.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,14 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                (!uri.Host.EndsWith(".googleusercontent.com") && !uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL. Must be a secure Google domain.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,14 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                (!uri.Host.EndsWith(".googleusercontent.com") && !uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL. Must be a secure Google domain.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in Google Photos Integration

🚨 Severity: CRITICAL
💡 Vulnerability: The application was vulnerable to Server-Side Request Forgery (SSRF) because it blindly accepted and fetched user-provided URLs (`GooglePhotoUrl`) in `Create.cshtml.cs` and `Edit.cshtml.cs` using `HttpClient.GetAsync()`. A malicious user could provide internal network URLs or malicious external URLs to probe the internal network or steal the provided Bearer token.
🎯 Impact: Could allow an attacker to probe internal network resources, leak the associated Google Photo Bearer token to a malicious domain, or perform denial-of-service attacks.
🔧 Fix: Implemented strict URI validation using `Uri.TryCreate` with `UriKind.Absolute` before fetching the image. Enforced that the scheme must be `https` and the host must end with either `.googleusercontent.com` or `.googleapis.com`.
✅ Verification: Ran `dotnet test` and verified tests continue to pass. Code review successfully approved the secure implementation.

---
*PR created automatically by Jules for task [2807954275768478062](https://jules.google.com/task/2807954275768478062) started by @whwar9739*