### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Server-Side Request Forgery in Google Photos Integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2026-05-21 - Server-Side Request Forgery (SSRF) in Google Photos Integration
+**Vulnerability:** The `GooglePhotoUrl` parameter in both `Create.cshtml.cs` and `Edit.cshtml.cs` was passed directly to `HttpClient.GetAsync()` without any validation. An attacker could provide a malicious URL pointing to internal network resources, potentially leading to Server-Side Request Forgery (SSRF).
+**Learning:** Always validate user-provided URLs before making outbound HTTP requests, especially when fetching resources from external services.
+**Prevention:** Strictly validate that the URI uses HTTPS and a trusted host (e.g., `.googleusercontent.com` or `.googleapis.com`) using `Uri.TryCreate` with `UriKind.Absolute` before invoking `HttpClient.GetAsync()`.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -50,14 +50,15 @@ public class CreateModel : PageModel
         {
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) || uri.Scheme != Uri.UriSchemeHttps || (!uri.Host.EndsWith(".googleusercontent.com") && !uri.Host.EndsWith(".googleapis.com"))) { ModelState.AddModelError("GooglePhotoUrl", "Invalid image URL."); return Page(); }
+            var response = await httpClient.GetAsync(uri);
             if (response.IsSuccessStatusCode)
             {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();
                 var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
                 var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
-                
+
                 var filePath = Path.Combine(uploadsFolder, uniqueFileName);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
                 NewWhiskey.ImageFileName = uniqueFileName;
@@ -74,7 +75,7 @@ public class CreateModel : PageModel
             }
 
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-            
+
             using (var fileStream = new FileStream(filePath, FileMode.Create))
             {
                 await ImageUpload.CopyToAsync(fileStream);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -64,7 +64,8 @@ public class EditModel : PageModel
         {
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) || uri.Scheme != Uri.UriSchemeHttps || (!uri.Host.EndsWith(".googleusercontent.com") && !uri.Host.EndsWith(".googleapis.com"))) { ModelState.AddModelError("GooglePhotoUrl", "Invalid image URL."); return Page(); }
+            var response = await httpClient.GetAsync(uri);
             if (response.IsSuccessStatusCode)
             {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();
@@ -74,7 +75,7 @@ public class EditModel : PageModel
 
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
-                
+
                 if (!string.IsNullOrEmpty(Whiskey.ImageFileName))
                 {
                     var oldPath = Path.Combine(uploadsFolder, Whiskey.ImageFileName);


### PR DESCRIPTION
Added URI validation to GooglePhotoUrl in Create and Edit endpoints to ensure the URL is absolute, uses HTTPS, and points to trusted Google domains.

---
*PR created automatically by Jules for task [9820307851688395382](https://jules.google.com/task/9820307851688395382) started by @whwar9739*