### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in Google Photos integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2025-05-22 - Server-Side Request Forgery (SSRF) in Google Photos Integration
+**Vulnerability:** The application was passing a user-provided URL (`GooglePhotoUrl`) directly into `HttpClient.GetAsync()` without validation in `Create.cshtml.cs` and `Edit.cshtml.cs`. This could allow an attacker to make the server perform unauthorized HTTP requests to arbitrary internal or external domains.
+**Learning:** Directly using user input in backend HTTP requests is a high-risk SSRF vector, especially when downloading resources or images.
+**Prevention:** Always parse and strictly validate user-provided URLs using `Uri.TryCreate`, enforce `https` schemes, and restrict allowed domains to a trusted whitelist (e.g., `*.googleusercontent.com`, `*.googleapis.com`) before making outgoing requests.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,15 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            // Validate the GooglePhotoUrl to prevent Server-Side Request Forgery (SSRF)
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uriResult) ||
+                uriResult.Scheme != Uri.UriSchemeHttps ||
+                !(uriResult.Host.EndsWith(".googleusercontent.com") || uriResult.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid or untrusted Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,15 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            // Validate the GooglePhotoUrl to prevent Server-Side Request Forgery (SSRF)
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uriResult) ||
+                uriResult.Scheme != Uri.UriSchemeHttps ||
+                !(uriResult.Host.EndsWith(".googleusercontent.com") || uriResult.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid or untrusted Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Server-Side Request Forgery (SSRF) in the Google Photos integration. The application accepted user-provided URLs (`GooglePhotoUrl`) and immediately passed them to `HttpClient.GetAsync()` without any validation in `Create.cshtml.cs` and `Edit.cshtml.cs`.
🎯 Impact: An attacker could force the server to perform HTTP GET requests to arbitrary internal resources (e.g., cloud metadata endpoints, internal services) or external domains.
🔧 Fix: Implemented strict URL validation. The input is now parsed using `Uri.TryCreate`, enforced to use the HTTPS scheme, and strictly whitelisted so the host must end with `.googleusercontent.com` or `.googleapis.com` before initiating any HTTP request.
✅ Verification: `dotnet test` passes. Visual inspection confirms URL verification blocks untrusted domains and only valid Google domains are queried.

---
*PR created automatically by Jules for task [678088383172733647](https://jules.google.com/task/678088383172733647) started by @whwar9739*