### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability in Google Photos integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2026-05-23 - SSRF Vulnerability in Google Photos Integration
+**Vulnerability:** The application allowed server-side request forgery (SSRF) by directly passing unvalidated, user-provided URLs (`GooglePhotoUrl`) to `HttpClient.GetAsync` during image uploads in `Create.cshtml.cs` and `Edit.cshtml.cs`.
+**Learning:** Blindly trusting URLs sent from the client (e.g., hidden form fields) can allow an attacker to force the server to make requests to internal network resources or malicious external sites.
+**Prevention:** When fetching resources from user-provided URLs, strictly validate that the URI uses HTTPS and a trusted host (e.g., `.googleusercontent.com` or `.googleapis.com`) using `Uri.TryCreate` with `UriKind.Absolute` before invoking `HttpClient.GetAsync()`.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,9 +48,18 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            // Security: Prevent SSRF by validating the URL
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var parsedUri) ||
+                parsedUri.Scheme != Uri.UriSchemeHttps ||
+                (!parsedUri.Host.EndsWith(".googleusercontent.com") && !parsedUri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid image source URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
+            var response = await httpClient.GetAsync(parsedUri);
             if (response.IsSuccessStatusCode)
             {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,9 +62,18 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            // Security: Prevent SSRF by validating the URL
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var parsedUri) ||
+                parsedUri.Scheme != Uri.UriSchemeHttps ||
+                (!parsedUri.Host.EndsWith(".googleusercontent.com") && !parsedUri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid image source URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
+            var response = await httpClient.GetAsync(parsedUri);
             if (response.IsSuccessStatusCode)
             {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The application allowed Server-Side Request Forgery (SSRF) by directly passing unvalidated, user-provided URLs (`GooglePhotoUrl`) to `HttpClient.GetAsync` during image uploads in `Create.cshtml.cs` and `Edit.cshtml.cs`.
🎯 Impact: An attacker could force the server to make unauthorized HTTP requests to internal network resources (e.g., cloud metadata services) or malicious external servers. This could lead to information disclosure or further compromise.
🔧 Fix: Added strict URL validation using `Uri.TryCreate` with `UriKind.Absolute` before the `HttpClient.GetAsync` call. This validation ensures that the scheme is `https` and the host ends with trusted Google domains (`.googleusercontent.com` or `.googleapis.com`).
✅ Verification: Tested image creation and editing with valid Google URLs. Simulated attacks with invalid URLs, which are now correctly blocked by the server with a model state error. Tests pass.

---
*PR created automatically by Jules for task [3876543438771373988](https://jules.google.com/task/3876543438771373988) started by @whwar9739*