### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Server-Side Request Forgery (SSRF) in Google Photos Integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-18 - SSRF Vulnerability in Google Photos Integration
+**Vulnerability:** The application allowed server-side requests to arbitrary URLs when importing photos from Google. The `GooglePhotoUrl` property was fetched directly via `HttpClient.GetAsync()` without any validation of the URI scheme or host.
+**Learning:** Always validate URLs provided by users (even through indirect integrations like photo pickers) before fetching them server-side to prevent SSRF attacks. Ensure the URI is absolute, uses HTTPS, and targets a trusted host.
+**Prevention:** Implement strict URI validation using `Uri.TryCreate` and check both the scheme and host against an allowlist before using `HttpClient`.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,14 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL. Must be a secure connection to Google services.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,14 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL. Must be a secure connection to Google services.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application was blindly passing user-provided input (`GooglePhotoUrl`) to `HttpClient.GetAsync()` without validation. This is a Server-Side Request Forgery (SSRF) vulnerability. An attacker could potentially coerce the server into making arbitrary HTTP GET requests to internal network services or external systems.
🎯 Impact: An attacker could scan internal networks, access cloud metadata services, or perform other malicious actions that the server has access to but an external attacker does not.
🔧 Fix: Added strict validation of `GooglePhotoUrl` in `Create.cshtml.cs` and `Edit.cshtml.cs`. It now uses `Uri.TryCreate` to ensure it's an absolute URL, enforces the HTTPS scheme, and strictly checks that the host ends with `.googleusercontent.com` or `.googleapis.com`. If validation fails, it securely adds a model error and rejects the request.
✅ Verification: Tested against tests and build successfully.

---
*PR created automatically by Jules for task [15861170216632021321](https://jules.google.com/task/15861170216632021321) started by @whwar9739*