### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-26 - Server-Side Request Forgery (SSRF) in Image Fetching
+**Vulnerability:** The application was vulnerable to Server-Side Request Forgery (SSRF) in `Create.cshtml.cs` and `Edit.cshtml.cs` when fetching images from `GooglePhotoUrl`. The provided URL was directly passed to `HttpClient.GetAsync()` without validation.
+**Learning:** Never trust user-provided URLs. Unvalidated URLs passed to backend HTTP clients can allow attackers to perform requests to internal networks or unauthenticated internal APIs.
+**Prevention:** Always validate URLs against an allowlist of trusted domains and enforce the HTTPS scheme before performing HTTP requests.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,16 +48,24 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                (!uri.Host.EndsWith(".googleusercontent.com") && !uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
+            var response = await httpClient.GetAsync(uri);
             if (response.IsSuccessStatusCode)
             {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();
                 var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
                 var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
-                
+
                 var filePath = Path.Combine(uploadsFolder, uniqueFileName);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
                 NewWhiskey.ImageFileName = uniqueFileName;
@@ -74,7 +82,7 @@ public class CreateModel : PageModel
             }
 
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-            
+
             using (var fileStream = new FileStream(filePath, FileMode.Create))
             {
                 await ImageUpload.CopyToAsync(fileStream);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,9 +62,17 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                (!uri.Host.EndsWith(".googleusercontent.com") && !uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
+            var response = await httpClient.GetAsync(uri);
             if (response.IsSuccessStatusCode)
             {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();
@@ -74,7 +82,7 @@ public class EditModel : PageModel
 
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
-                
+
                 if (!string.IsNullOrEmpty(Whiskey.ImageFileName))
                 {
                     var oldPath = Path.Combine(uploadsFolder, Whiskey.ImageFileName);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application was vulnerable to Server-Side Request Forgery (SSRF) when fetching images via `GooglePhotoUrl`.
🎯 Impact: Attackers could potentially access internal networks or APIs.
🔧 Fix: Validated URLs against a trusted allowlist (.googleusercontent.com, .googleapis.com) and enforced HTTPS.
✅ Verification: Ensure valid Google Photos URLs still work, while others are rejected with a model error.

---
*PR created automatically by Jules for task [2554783131255587685](https://jules.google.com/task/2554783131255587685) started by @whwar9739*