### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photos Integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-24 - SSRF via Unrestricted HttpClient.GetAsync
+**Vulnerability:** The application fetched images from user-provided URLs (`GooglePhotoUrl` in `Create.cshtml.cs` and `Edit.cshtml.cs`) using `HttpClient.GetAsync()` without any validation. This exposed the application to Server-Side Request Forgery (SSRF), allowing an attacker to coerce the server into making requests to internal or external resources.
+**Learning:** Never pass unsanitized user input directly to HTTP clients. Always validate that URIs are safe and meet expected criteria.
+**Prevention:** Always use `Uri.TryCreate` to ensure the URI is absolute, enforces HTTPS, and strictly whitelist allowed hosts (e.g., `.googleusercontent.com` or `.googleapis.com`) before invoking `HttpClient.GetAsync()`.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,16 +48,24 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var photoUri) ||
+                photoUri.Scheme != Uri.UriSchemeHttps ||
+                (!photoUri.Host.EndsWith(".googleusercontent.com") && !photoUri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photos URL provided.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
+            var response = await httpClient.GetAsync(photoUri);
             if (response.IsSuccessStatusCode)
             {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();
                 var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
                 var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
-                
+
                 var filePath = Path.Combine(uploadsFolder, uniqueFileName);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
                 NewWhiskey.ImageFileName = uniqueFileName;
@@ -74,7 +82,7 @@ public class CreateModel : PageModel
             }
 
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-            
+
             using (var fileStream = new FileStream(filePath, FileMode.Create))
             {
                 await ImageUpload.CopyToAsync(fileStream);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,9 +62,17 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var photoUri) ||
+                photoUri.Scheme != Uri.UriSchemeHttps ||
+                (!photoUri.Host.EndsWith(".googleusercontent.com") && !photoUri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photos URL provided.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
+            var response = await httpClient.GetAsync(photoUri);
             if (response.IsSuccessStatusCode)
             {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();
@@ -74,7 +82,7 @@ public class EditModel : PageModel
 
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
-                
+
                 if (!string.IsNullOrEmpty(Whiskey.ImageFileName))
                 {
                     var oldPath = Path.Combine(uploadsFolder, Whiskey.ImageFileName);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application fetched images from user-provided URLs (GooglePhotoUrl) using HttpClient.GetAsync() without any validation. This exposed the application to Server-Side Request Forgery (SSRF), allowing an attacker to coerce the server into making requests to internal or external resources.
🎯 Impact: An attacker could force the server to make requests to arbitrary URLs, potentially accessing internal network resources, reading local files, or port scanning internal networks.
🔧 Fix: Validated that GooglePhotoUrl is an absolute URI, enforces HTTPS, and strictly whitelisted allowed hosts (.googleusercontent.com or .googleapis.com) before invoking HttpClient.GetAsync().
✅ Verification: Ensure the updated logic handles invalid URLs securely by returning Page() with a ModelState error.

---
*PR created automatically by Jules for task [5298525296612668314](https://jules.google.com/task/5298525296612668314) started by @whwar9739*