### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Server-Side Request Forgery (SSRF) in Google Photos

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-18 - SSRF Vulnerability in Google Photos Integration
+**Vulnerability:** The application fetches image resources based on user-provided URLs in `Create.cshtml.cs` and `Edit.cshtml.cs` using `HttpClient.GetAsync()`. The URL was not validated, allowing potential Server-Side Request Forgery (SSRF) attacks where a user could provide internal network URLs or malicious external URLs to be fetched by the server.
+**Learning:** Never trust user-provided URLs when making outbound HTTP requests from the server.
+**Prevention:** Always use `Uri.TryCreate` with `UriKind.Absolute` to strictly validate the user-provided URL. Ensure the scheme is `https` and restrict the host to specific trusted domains (e.g., `.googleusercontent.com` or `.googleapis.com`) before invoking `HttpClient.GetAsync()`.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,14 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid or untrusted Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,14 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid or untrusted Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application fetched resources based on unvalidated user-provided URLs (`GooglePhotoUrl`) using `HttpClient.GetAsync()`. This allowed for SSRF attacks where malicious users could trick the server into making requests to internal network services or malicious external domains.
🎯 Impact: Attackers could potentially access internal resources behind the firewall, bypass IP whitelisting, or conduct port scanning.
🔧 Fix: Validated the `GooglePhotoUrl` strictly using `Uri.TryCreate` with `UriKind.Absolute`, ensuring the scheme is `https` and the host targets trusted domains (`.googleusercontent.com` or `.googleapis.com`) before invoking the HTTP client.
✅ Verification: Review the code to ensure URL validation exists in both `Create.cshtml.cs` and `Edit.cshtml.cs`. Run `dotnet test` to verify no regressions.

---
*PR created automatically by Jules for task [6597760943594755790](https://jules.google.com/task/6597760943594755790) started by @whwar9739*