### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Server-Side Request Forgery on external image URLs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2026-05-31 - Missing SSRF Validation on Image Uploads from External URLs
+**Vulnerability:** The application was executing `HttpClient.GetAsync()` on user-provided Google Photos URLs without validation, opening up a Server-Side Request Forgery (SSRF) risk where a user could trick the server into downloading malicious or internal files.
+**Learning:** `HttpClient.GetAsync()` blindly trusts whatever URL it is fed, and any time a user provides a URL to fetch a resource, it must be explicitly validated.
+**Prevention:** Before performing an outbound HTTP request using a user-provided URL, parse the URI using `Uri.TryCreate` with `UriKind.Absolute`, enforce the `https` scheme, and explicitly whitelist acceptable hosts (e.g., `.googleusercontent.com` or `.googleapis.com`).

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,14 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid or untrusted Google Photos URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,14 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid or untrusted Google Photos URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application was fetching user-provided Google Photos URLs without validation, creating a Server-Side Request Forgery (SSRF) risk.
🎯 Impact: An attacker could trick the server into making arbitrary HTTP requests to internal networks or malicious endpoints.
🔧 Fix: Implemented URI scheme and domain validation using Uri.TryCreate to ensure only https URLs from .googleusercontent.com or .googleapis.com are fetched.
✅ Verification: dotnet test runs successfully, and the validation logic rejects invalid or untrusted URLs.

Updates .jules/sentinel.md with critical learnings.

---
*PR created automatically by Jules for task [8922559448866329379](https://jules.google.com/task/8922559448866329379) started by @whwar9739*