### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF and Path Traversal in Image Uploads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2025-02-28 - SSRF and Path Traversal in File Uploads
+**Vulnerability:** The application was vulnerable to Server-Side Request Forgery (SSRF) by accepting an unvalidated `GooglePhotoUrl` and making outbound HTTP GET requests with a sensitive Bearer token attached. Additionally, the file upload mechanism was vulnerable to Path Traversal, as user-controlled filenames (`ImageUpload.FileName`) were concatenated directly to a GUID, potentially allowing files to be written outside the intended directory.
+**Learning:** Never trust external URLs or user-provided filenames. Outbound requests to user-provided URLs can be manipulated to scan internal networks or leak tokens. User-provided filenames can contain malicious sequences like `../../../`.
+**Prevention:** Strictly validate external URLs using `Uri.TryCreate` with `UriKind.Absolute` to ensure HTTPS and a trusted host. For file uploads, always extract only the file extension using `Path.GetExtension()` and append it to a randomly generated GUID.

--- a/WhiskeyTracker.Tests/WhiskiesTests.cs
+++ b/WhiskeyTracker.Tests/WhiskiesTests.cs
@@ -44,7 +44,7 @@ public class WhiskiesTests : TestBase
         await context.SaveChangesAsync();
 
         var legacyService = new WhiskeyTracker.Web.Services.LegacyMigrationService(context);
-        
+
         // Search matches Brand
         var pageModel = new IndexModel(context, legacyService) { SearchString = "William" };
         SetMockUser(pageModel, "test-user");
@@ -126,7 +126,7 @@ public class WhiskiesTests : TestBase
         Assert.IsType<RedirectToPageResult>(result);
         var whiskey = await context.Whiskies.FirstAsync();
         Assert.Equal("Test Whiskey", whiskey.Name);
-        Assert.Contains("test.jpg", whiskey.ImageFileName); // Confirms filename was generated
+        Assert.True(whiskey.ImageFileName.EndsWith(".jpg")); // Confirms filename was generated and extension preserved
     }
 
     [Fact]
@@ -140,8 +140,8 @@ public class WhiskiesTests : TestBase
 
         var pageModel = new CreateModel(context, mockEnv.Object)
         {
-            NewWhiskey = new Whiskey 
-            { 
+            NewWhiskey = new Whiskey
+            {
                 Name = "No Cask Whiskey",
                 Distillery = "Test Distillery",
                 CaskType = null // Explicitly null
@@ -477,7 +477,7 @@ public class WhiskiesTests : TestBase
         Assert.NotNull(updatedWhiskey);
         Assert.NotNull(updatedWhiskey.ImageFileName);
         Assert.NotEqual(oldFileName, updatedWhiskey.ImageFileName);
-        Assert.Contains(newFileName, updatedWhiskey.ImageFileName);
+        Assert.True(updatedWhiskey.ImageFileName.EndsWith(".jpg"));
         Assert.False(File.Exists(oldFilePath));
         Assert.True(File.Exists(Path.Combine(tempPath, "images", updatedWhiskey.ImageFileName)));
 

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,14 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                (!uri.Host.EndsWith(".googleusercontent.com") && !uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid or untrusted Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
@@ -65,7 +73,7 @@ public class CreateModel : PageModel
         }
         else if (ImageUpload != null)
         {
-            var uniqueFileName = Guid.NewGuid().ToString() + "_" + ImageUpload.FileName;
+            var uniqueFileName = Guid.NewGuid().ToString() + Path.GetExtension(ImageUpload.FileName);
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
 
             if (!Directory.Exists(uploadsFolder))

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,14 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                (!uri.Host.EndsWith(".googleusercontent.com") && !uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid or untrusted Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
@@ -86,7 +94,7 @@ public class EditModel : PageModel
         }
         else if (ImageUpload != null)
         {
-            var uniqueFileName = Guid.NewGuid().ToString() + "_" + ImageUpload.FileName;
+            var uniqueFileName = Guid.NewGuid().ToString() + Path.GetExtension(ImageUpload.FileName);
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
 


### PR DESCRIPTION
🚨 **Severity**: CRITICAL

💡 **Vulnerability**: 
1. **Server-Side Request Forgery (SSRF)**: The application accepted unvalidated user-provided Google Photo URLs, making outbound HTTP requests and attaching a sensitive Bearer token.
2. **Path Traversal**: Direct file uploads used the user-provided filename concatenated with a GUID, allowing potential injection of malicious path sequences (e.g., `../../../`) to write files outside intended directories.

🎯 **Impact**: An attacker could provide a malicious URL to steal the attached Bearer token or scan internal networks. Additionally, an attacker could upload arbitrary files to critical server directories via Path Traversal.

🔧 **Fix**: 
1. Validated the `GooglePhotoUrl` using `Uri.TryCreate` to ensure it uses `HTTPS` and points to trusted Google domains (`.googleusercontent.com` or `.googleapis.com`).
2. Updated file upload logic to extract only the file extension from `ImageUpload.FileName` using `Path.GetExtension()`, completely removing reliance on the user-provided base filename.

✅ **Verification**: 
1. Run `dotnet test` to verify all unit tests continue to pass.
2. Attempt to input a non-Google URL or an arbitrary HTTP URL in the Google Photos import flow - it should be rejected.
3. Attempt to upload a file with a malicious filename (e.g., `../../../test.jpg`) - it will be safely saved as `{GUID}.jpg`.

---
*PR created automatically by Jules for task [3042560668062232485](https://jules.google.com/task/3042560668062232485) started by @whwar9739*