### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photos Integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-24 - Missing Input Validation on Image Upload Integration
+**Vulnerability:** Server-Side Request Forgery (SSRF) allowed external, attacker-controlled URLs to be fetched via `HttpClient.GetAsync(GooglePhotoUrl)` without proper host or scheme validation in `Create.cshtml.cs` and `Edit.cshtml.cs`.
+**Learning:** Automatically trusting user-provided URLs in HTTP clients opens the door to fetching local or restricted network resources, or arbitrary external files.
+**Prevention:** Strictly validate external URIs with `Uri.TryCreate` specifying `UriKind.Absolute`, requiring HTTPS, and restricting hosts to known trusted domains (e.g., `.googleusercontent.com`, `.googleapis.com`).

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,15 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            // SSRF Protection: Validate URL scheme and host before making the request
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                (!uri.Host.EndsWith(".googleusercontent.com") && !uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError(string.Empty, "Invalid Google Photo URL provided.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,15 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            // SSRF Protection: Validate URL scheme and host before making the request
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                (!uri.Host.EndsWith(".googleusercontent.com") && !uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError(string.Empty, "Invalid Google Photo URL provided.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Server-Side Request Forgery (SSRF) allowed external, attacker-controlled URLs to be fetched via `HttpClient.GetAsync(GooglePhotoUrl)` without proper host or scheme validation.
🎯 **Impact:** An attacker could potentially bypass firewall rules to interact with internal services or exploit cloud metadata APIs by supplying arbitrary domains or IP addresses. In addition, the Bearer token would be forwarded to untrusted domains.
🔧 **Fix:** Added strict URL validation using `Uri.TryCreate` specifying `UriKind.Absolute`. The fix requires the scheme to be HTTPS and restricts the allowed hosts to explicitly trusted Google domains (`.googleusercontent.com`, `.googleapis.com`).
✅ **Verification:** Attempting to submit a URL that does not meet these exact criteria triggers a ModelState error and is rejected.

---
*PR created automatically by Jules for task [618350716914859394](https://jules.google.com/task/618350716914859394) started by @whwar9739*