### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photos integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-16 - Unvalidated External URLs Leading to SSRF
+**Vulnerability:** The Google Photos integration allowed arbitrary URLs supplied by users to be fetched using `HttpClient.GetAsync()` without any validation. This meant an attacker could supply a URL pointing to internal network services or metadata endpoints, potentially leading to Server-Side Request Forgery (SSRF).
+**Learning:** Any user-supplied URL that the server will fetch must be strictly validated. Checking only the token is insufficient if the URL itself can be manipulated to point elsewhere.
+**Prevention:** Strictly validate that any externally fetched URI uses HTTPS and its host strictly matches a predefined list of trusted domains (e.g., `.googleusercontent.com` or `.googleapis.com`) using `Uri.TryCreate` with `UriKind.Absolute` before invoking `HttpClient.GetAsync()`.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,14 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                (!uri.Host.EndsWith(".googleusercontent.com") && !uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,14 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                (!uri.Host.EndsWith(".googleusercontent.com") && !uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,5 @@
+🚨 Severity: CRITICAL
+💡 Vulnerability: Google Photos integration allowed arbitrary URLs supplied by users to be fetched using `HttpClient.GetAsync()` without validation.
+🎯 Impact: Attackers could supply a URL pointing to internal network services or metadata endpoints, potentially leading to Server-Side Request Forgery (SSRF).
+🔧 Fix: Added strict URL validation using `Uri.TryCreate` with `UriKind.Absolute` before invoking `HttpClient.GetAsync()`. The fix ensures the URL uses HTTPS and the host matches either `.googleusercontent.com` or `.googleapis.com`.
+✅ Verification: Ensure the test suite passes, and trying to supply a non-Google URL or non-HTTPS URL in the `GooglePhotoUrl` field results in a model validation error.


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Google Photos integration allowed arbitrary URLs supplied by users to be fetched using `HttpClient.GetAsync()` without validation.
🎯 Impact: Attackers could supply a URL pointing to internal network services or metadata endpoints, potentially leading to Server-Side Request Forgery (SSRF).
🔧 Fix: Added strict URL validation using `Uri.TryCreate` with `UriKind.Absolute` before invoking `HttpClient.GetAsync()`. The fix ensures the URL uses HTTPS and the host matches either `.googleusercontent.com` or `.googleapis.com`.
✅ Verification: Ensure the test suite passes, and trying to supply a non-Google URL or non-HTTPS URL in the `GooglePhotoUrl` field results in a model validation error.

---
*PR created automatically by Jules for task [2877046536661474713](https://jules.google.com/task/2877046536661474713) started by @whwar9739*