### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in Google Photos integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2025-02-23 - SSRF Vulnerability in Google Photos Integration
+**Vulnerability:** The application was directly passing a user-provided `GooglePhotoUrl` to `HttpClient.GetAsync()` without any validation in `Create.cshtml.cs` and `Edit.cshtml.cs`. This allowed potential Server-Side Request Forgery (SSRF).
+**Learning:** External integrations that accept URLs must strictly validate the scheme and host to ensure they only connect to intended, trusted endpoints.
+**Prevention:** Always use `Uri.TryCreate` with `UriKind.Absolute` to validate the URL structure, and explicitly check that the scheme is HTTPS and the host matches an allowlist of trusted domains before making outbound HTTP requests.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,15 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            // Security: Prevent SSRF by validating the URL before making HTTP requests
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError(string.Empty, "Invalid or untrusted Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,15 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            // Security: Prevent SSRF by validating the URL before making HTTP requests
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError(string.Empty, "Invalid or untrusted Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The application was directly passing a user-provided `GooglePhotoUrl` to `HttpClient.GetAsync()` without any validation in `Create.cshtml.cs` and `Edit.cshtml.cs`. This allowed potential Server-Side Request Forgery (SSRF).
🎯 **Impact:** An attacker could potentially use the server to make requests to internal network resources or unauthorized external services.
🔧 **Fix:** Added strict scheme and host validation using `Uri.TryCreate` to ensure the URL is HTTPS and points to trusted domains (`.googleusercontent.com` or `.googleapis.com`) before executing the request.
✅ **Verification:** Verified by checking that invalid or untrusted URLs are rejected with a model error, and running the test suite to ensure existing functionality remains intact.

---
*PR created automatically by Jules for task [14235562702857071705](https://jules.google.com/task/14235562702857071705) started by @whwar9739*