### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photos Integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-06-07 - Server-Side Request Forgery (SSRF) via Google Photos Integration
+**Vulnerability:** The application allowed arbitrary internal/external HTTP requests through the Google Photos URL parameter (`GooglePhotoUrl`) in `WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs` and `WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs` because it passed unsanitized user input directly to `HttpClient.GetAsync()`.
+**Learning:** Cloud-based integrations that fetch external resources can be abused to port scan internal networks or access internal metadata services (e.g., AWS IMDS 169.254.169.254) if URLs are not strictly validated against a known whitelist.
+**Prevention:** When fetching resources from user-provided URLs (like the Google Photos integration), strictly validate that the URI uses HTTPS and a trusted host (e.g., '.googleusercontent.com' or '.googleapis.com') using `Uri.TryCreate` with `UriKind.Absolute` before invoking `HttpClient.GetAsync()`.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,6 +48,14 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,6 +62,14 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL.");
+                return Page();
+            }
+
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Server-Side Request Forgery (SSRF) allowed arbitrary HTTP requests to internal/external networks via the `GooglePhotoUrl` parameter because the input was directly passed to `HttpClient.GetAsync()` without sanitization or validation.
🎯 Impact: Attackers could potentially port scan internal networks, access sensitive internal resources (like AWS IMDS metadata at 169.254.169.254), or use the application as a proxy for external attacks.
🔧 Fix: Validated that the `GooglePhotoUrl` is an absolute HTTPS URI and the host explicitly ends with either `.googleusercontent.com` or `.googleapis.com` using `Uri.TryCreate` before executing the HTTP request.
✅ Verification: `dotnet test` tests continue to pass. Tested against arbitrary URLs and only Google domains are processed.

---
*PR created automatically by Jules for task [16023647640932551363](https://jules.google.com/task/16023647640932551363) started by @whwar9739*