### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photos Integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-06-09 - Missing SSRF Protection in Google Photos Integration
+**Vulnerability:** The application was vulnerable to Server-Side Request Forgery (SSRF) because it blindly passed a user-controlled `GooglePhotoUrl` directly into `HttpClient.GetAsync()` without validating the scheme, host, or URL format. This could allow an attacker to make the server perform HTTP requests to arbitrary internal or external addresses.
+**Learning:** Always explicitly validate the URL structure (using `Uri.TryCreate`) and verify that it matches expected parameters (e.g., specific HTTPS domains) before performing HTTP requests based on user input.
+**Prevention:** Always validate URLs to ensure they use HTTPS and belong to a trusted domain before invoking `HttpClient.GetAsync()` when fetching external resources.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,7 +48,16 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL. Must be a secure link from Google Photos.");
+                return Page();
+            }
+
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,7 +62,16 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL. Must be a secure link from Google Photos.");
+                return Page();
+            }
+
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)

--- a/pr_desc.txt
+++ b/pr_desc.txt
@@ -1,0 +1,5 @@
+🚨 Severity: CRITICAL
+💡 Vulnerability: The application was vulnerable to Server-Side Request Forgery (SSRF) because it passed user-controlled `GooglePhotoUrl` inputs directly into `HttpClient.GetAsync()` without validation.
+🎯 Impact: This could allow an attacker to trick the server into making requests to internal services or external domains, potentially leaking sensitive data.
+🔧 Fix: Added URI validation to strictly check for HTTPS and restrict the host to trusted Google domains (`.googleusercontent.com` and `.googleapis.com`). Also added `HttpClientHandler` with `AllowAutoRedirect = false` to prevent arbitrary redirects.
+✅ Verification: Review the code to ensure URL validation and redirect restrictions are in place before `HttpClient` makes requests in `Create.cshtml.cs` and `Edit.cshtml.cs`. All automated tests continue to pass.


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application was vulnerable to Server-Side Request Forgery (SSRF) because it passed user-controlled `GooglePhotoUrl` inputs directly into `HttpClient.GetAsync()` without validation.
🎯 Impact: This could allow an attacker to trick the server into making requests to internal services or external domains, potentially leaking sensitive data.
🔧 Fix: Added URI validation to strictly check for HTTPS and restrict the host to trusted Google domains (`.googleusercontent.com` and `.googleapis.com`). Also added `HttpClientHandler` with `AllowAutoRedirect = false` to prevent arbitrary redirects.
✅ Verification: Review the code to ensure URL validation and redirect restrictions are in place before `HttpClient` makes requests in `Create.cshtml.cs` and `Edit.cshtml.cs`. All automated tests continue to pass.

---
*PR created automatically by Jules for task [8370244770407382463](https://jules.google.com/task/8370244770407382463) started by @whwar9739*