### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in Google Photos integration

### DIFF
--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,9 +48,19 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            // Security: Prevent SSRF by validating the URL and disabling auto-redirects
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photos URL.");
+                return Page();
+            }
+
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
+            var response = await httpClient.GetAsync(uri);
             if (response.IsSuccessStatusCode)
             {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,9 +62,19 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            // Security: Prevent SSRF by validating the URL and disabling auto-redirects
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photos URL.");
+                return Page();
+            }
+
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
+            var response = await httpClient.GetAsync(uri);
             if (response.IsSuccessStatusCode)
             {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The application accepted user-provided URLs for fetching Google Photos (`GooglePhotoUrl`) and directly executed `HttpClient.GetAsync()` without validating the URL scheme, host, or disabling auto-redirects. This exposed the application to Server-Side Request Forgery (SSRF).
🎯 **Impact:** Allowed attackers to potentially scan internal networks or fetch internal resources bypassing initial validation via a malicious server redirect.
🔧 **Fix:** Added validation for `GooglePhotoUrl` to ensure the scheme is HTTPS and the host belongs to `*.googleusercontent.com` or `*.googleapis.com`. Also, explicitly disabled automatic redirects on the `HttpClient` using `HttpClientHandler { AllowAutoRedirect = false }`.
✅ **Verification:** Verified by unit tests passing. Code changes restrict URL parameters significantly.

---
*PR created automatically by Jules for task [8604137215239426337](https://jules.google.com/task/8604137215239426337) started by @whwar9739*