### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF in Google Photos Integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-06-11 - SSRF via Google Photos Integration
+**Vulnerability:** The application was vulnerable to SSRF because it used a raw `HttpClient` to fetch user-provided URLs in `GooglePhotoUrl` without URL scheme or domain validation, and allowing auto-redirects.
+**Learning:** External image fetch features must validate that URLs are not only syntactically correct but restricted to trusted schemes (HTTPS) and specific trusted host domains (e.g. `googleusercontent.com`).
+**Prevention:** Always use `Uri.TryCreate` with `UriKind.Absolute` to validate the schema, explicitly check hostnames against an allowlist, and use `HttpClientHandler { AllowAutoRedirect = false }` to prevent redirect chaining to internal network resources.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,19 +48,25 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
-            if (response.IsSuccessStatusCode)
+            if (Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) &&
+                uri.Scheme == Uri.UriSchemeHttps &&
+                (uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com") || uri.Host == "googleusercontent.com" || uri.Host == "googleapis.com"))
             {
+                using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+                using var httpClient = new HttpClient(handler);
+                httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
+                var response = await httpClient.GetAsync(GooglePhotoUrl);
+                if (response.IsSuccessStatusCode)
+                {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();
                 var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
                 var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
-                
-                var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-                await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
-                NewWhiskey.ImageFileName = uniqueFileName;
+
+                    var filePath = Path.Combine(uploadsFolder, uniqueFileName);
+                    await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
+                    NewWhiskey.ImageFileName = uniqueFileName;
+                }
             }
         }
         else if (ImageUpload != null)
@@ -74,7 +80,7 @@ public class CreateModel : PageModel
             }
 
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-            
+
             using (var fileStream = new FileStream(filePath, FileMode.Create))
             {
                 await ImageUpload.CopyToAsync(fileStream);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,11 +62,16 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
-            if (response.IsSuccessStatusCode)
+            if (Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) &&
+                uri.Scheme == Uri.UriSchemeHttps &&
+                (uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com") || uri.Host == "googleusercontent.com" || uri.Host == "googleapis.com"))
             {
+                using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+                using var httpClient = new HttpClient(handler);
+                httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
+                var response = await httpClient.GetAsync(GooglePhotoUrl);
+                if (response.IsSuccessStatusCode)
+                {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();
                 var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
                 var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
@@ -74,14 +79,15 @@ public class EditModel : PageModel
 
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
-                
-                if (!string.IsNullOrEmpty(Whiskey.ImageFileName))
-                {
-                    var oldPath = Path.Combine(uploadsFolder, Whiskey.ImageFileName);
-                    if (System.IO.File.Exists(oldPath)) System.IO.File.Delete(oldPath);
-                }
 
-                Whiskey.ImageFileName = uniqueFileName;
+                    if (!string.IsNullOrEmpty(Whiskey.ImageFileName))
+                    {
+                        var oldPath = Path.Combine(uploadsFolder, Whiskey.ImageFileName);
+                        if (System.IO.File.Exists(oldPath)) System.IO.File.Delete(oldPath);
+                    }
+
+                    Whiskey.ImageFileName = uniqueFileName;
+                }
             }
         }
         else if (ImageUpload != null)


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The application accepted arbitrary URLs via `GooglePhotoUrl` without validation and fetched them using a default `HttpClient`.
🎯 Impact: Attackers could cause the server to make arbitrary HTTP requests, potentially accessing internal network resources or leaking the `GooglePhotoToken` via HTTP headers on redirect.
🔧 Fix: Added strict URL validation ensuring the scheme is HTTPS and the host matches an allowed Google domain (`*.googleusercontent.com` or `*.googleapis.com`). Also disabled auto-redirects on the `HttpClient` to prevent redirect chaining.
✅ Verification: Ensure tests pass. Valid Google Photos URLs are fetched correctly while invalid or malicious URLs fail securely.

---
*PR created automatically by Jules for task [15684599086390092266](https://jules.google.com/task/15684599086390092266) started by @whwar9739*