### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF and Path Traversal in file uploads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2026-06-12 - SSRF and Path Traversal in File Uploads
+**Vulnerability:** Google Photos integrations in `WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs` and `Edit.cshtml.cs` lacked URL validation, enabling Server-Side Request Forgery (SSRF) and potential redirect attacks. File uploads combined user-provided filenames with GUIDs, enabling potential path traversal or conflicting naming via `+ "_" + ImageUpload.FileName`.
+**Learning:** External URLs provided via client input must be strictly validated for trusted hosts and HTTPS, and `HttpClient` auto-redirects disabled, to prevent SSRF. For file uploads, user-provided filenames should be fully discarded in favor of server-generated unique identifiers, preserving only the extension.
+**Prevention:** Use `Uri.TryCreate` with absolute paths, validate `.Host` against an allowlist, use `new HttpClientHandler { AllowAutoRedirect = false }`, and use `Path.GetExtension(filename)` rather than appending the full user-provided filename.

--- a/WhiskeyTracker.Tests/WhiskiesTests.cs
+++ b/WhiskeyTracker.Tests/WhiskiesTests.cs
@@ -126,7 +126,7 @@ public class WhiskiesTests : TestBase
         Assert.IsType<RedirectToPageResult>(result);
         var whiskey = await context.Whiskies.FirstAsync();
         Assert.Equal("Test Whiskey", whiskey.Name);
-        Assert.Contains("test.jpg", whiskey.ImageFileName); // Confirms filename was generated
+        Assert.EndsWith(".jpg", whiskey.ImageFileName); // Confirms filename was generated
     }
 
     [Fact]
@@ -477,7 +477,7 @@ public class WhiskiesTests : TestBase
         Assert.NotNull(updatedWhiskey);
         Assert.NotNull(updatedWhiskey.ImageFileName);
         Assert.NotEqual(oldFileName, updatedWhiskey.ImageFileName);
-        Assert.Contains(newFileName, updatedWhiskey.ImageFileName);
+        Assert.EndsWith(".jpg", updatedWhiskey.ImageFileName);
         Assert.False(File.Exists(oldFilePath));
         Assert.True(File.Exists(Path.Combine(tempPath, "images", updatedWhiskey.ImageFileName)));
 

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,24 +48,30 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
-            if (response.IsSuccessStatusCode)
+            if (Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uriResult)
+                && uriResult.Scheme == Uri.UriSchemeHttps
+                && (uriResult.Host.EndsWith(".googleusercontent.com") || uriResult.Host.EndsWith(".googleapis.com")))
             {
-                var imageBytes = await response.Content.ReadAsByteArrayAsync();
-                var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
-                var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
-                if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
-                
-                var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-                await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
-                NewWhiskey.ImageFileName = uniqueFileName;
+                using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+                using var httpClient = new HttpClient(handler);
+                httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
+                var response = await httpClient.GetAsync(GooglePhotoUrl);
+                if (response.IsSuccessStatusCode)
+                {
+                    var imageBytes = await response.Content.ReadAsByteArrayAsync();
+                    var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
+                    var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
+                    if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
+
+                    var filePath = Path.Combine(uploadsFolder, uniqueFileName);
+                    await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
+                    NewWhiskey.ImageFileName = uniqueFileName;
+                }
             }
         }
         else if (ImageUpload != null)
         {
-            var uniqueFileName = Guid.NewGuid().ToString() + "_" + ImageUpload.FileName;
+            var uniqueFileName = Guid.NewGuid().ToString() + Path.GetExtension(ImageUpload.FileName);
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
 
             if (!Directory.Exists(uploadsFolder))

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,31 +62,37 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
-            if (response.IsSuccessStatusCode)
+            if (Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uriResult)
+                && uriResult.Scheme == Uri.UriSchemeHttps
+                && (uriResult.Host.EndsWith(".googleusercontent.com") || uriResult.Host.EndsWith(".googleapis.com")))
             {
-                var imageBytes = await response.Content.ReadAsByteArrayAsync();
-                var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
-                var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
-                var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-
-                if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
-                await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
-                
-                if (!string.IsNullOrEmpty(Whiskey.ImageFileName))
+                using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+                using var httpClient = new HttpClient(handler);
+                httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
+                var response = await httpClient.GetAsync(GooglePhotoUrl);
+                if (response.IsSuccessStatusCode)
                 {
-                    var oldPath = Path.Combine(uploadsFolder, Whiskey.ImageFileName);
-                    if (System.IO.File.Exists(oldPath)) System.IO.File.Delete(oldPath);
-                }
+                    var imageBytes = await response.Content.ReadAsByteArrayAsync();
+                    var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
+                    var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
+                    var filePath = Path.Combine(uploadsFolder, uniqueFileName);
 
-                Whiskey.ImageFileName = uniqueFileName;
+                    if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
+                    await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
+
+                    if (!string.IsNullOrEmpty(Whiskey.ImageFileName))
+                    {
+                        var oldPath = Path.Combine(uploadsFolder, Whiskey.ImageFileName);
+                        if (System.IO.File.Exists(oldPath)) System.IO.File.Delete(oldPath);
+                    }
+
+                    Whiskey.ImageFileName = uniqueFileName;
+                }
             }
         }
         else if (ImageUpload != null)
         {
-            var uniqueFileName = Guid.NewGuid().ToString() + "_" + ImageUpload.FileName;
+            var uniqueFileName = Guid.NewGuid().ToString() + Path.GetExtension(ImageUpload.FileName);
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Google Photos integrations in `Create.cshtml.cs` and `Edit.cshtml.cs` lacked URL validation, enabling SSRF. User-provided filenames were appended to GUIDs in file uploads, enabling potential path traversal.
🎯 **Impact:** Attackers could force the server to issue requests to arbitrary internal services (SSRF) and potentially write files to arbitrary locations or cause naming conflicts (Path Traversal).
🔧 **Fix:** Added URL validation and `HttpClientHandler { AllowAutoRedirect = false }` to prevent SSRF. Updated file uploads to use `Path.GetExtension(filename)` rather than the full user-provided filename.
✅ **Verification:** Unit tests have been run and pass with the modified assertions.

---
*PR created automatically by Jules for task [2569198611871161228](https://jules.google.com/task/2569198611871161228) started by @whwar9739*