### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photo Fetching

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+## 2025-02-28 - SSRF Vulnerability in Google Photos Integration
+**Vulnerability:** Server-Side Request Forgery (SSRF) allowed the server to fetch images from any URL provided in `GooglePhotoUrl` without validation, posing a risk of internal network scanning or accessing unintended internal services.
+**Learning:** External URLs provided via client requests and fetched by `HttpClient` must be strictly validated. The scheme and domain should be constrained, and `HttpClient` auto-redirects must be disabled to prevent attackers from bypassing domain restrictions via redirect responses.
+**Prevention:** Implement an allowlist approach for expected external hosts (e.g., `*.googleusercontent.com` and `*.googleapis.com`), enforce HTTPS using `Uri.TryCreate`, and use `new HttpClientHandler { AllowAutoRedirect = false }` when instantiating the `HttpClient`.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,7 +48,16 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var parsedUri) ||
+                parsedUri.Scheme != Uri.UriSchemeHttps ||
+                !(parsedUri.Host.EndsWith(".googleusercontent.com") || parsedUri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError(string.Empty, "Invalid Google Photo URL.");
+                return Page();
+            }
+
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,7 +62,16 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var parsedUri) ||
+                parsedUri.Scheme != Uri.UriSchemeHttps ||
+                !(parsedUri.Host.EndsWith(".googleusercontent.com") || parsedUri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError(string.Empty, "Invalid Google Photo URL.");
+                return Page();
+            }
+
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Server-Side Request Forgery (SSRF) when fetching images.
🎯 Impact: An attacker could pass internal network URLs to scan ports or access internal services.
🔧 Fix: Validated the URL protocol to HTTPS, ensured the hostname ends with googleusercontent.com or googleapis.com, and disabled HttpClient auto-redirects.
✅ Verification: Tested image URL fetching.

---
*PR created automatically by Jules for task [16504196000858288233](https://jules.google.com/task/16504196000858288233) started by @whwar9739*