### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photos Integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-24 - SSRF Vulnerability in Google Photos Integration
+**Vulnerability:** The application fetched Google Photos images using a user-provided `GooglePhotoUrl` without validating the host, scheme, or restricting HTTP redirects. This could allow an attacker to make the server fetch resources from internal networks or arbitrary endpoints (SSRF).
+**Learning:** Even when integrating with third-party services like Google Photos, user-provided URLs must be strictly validated to ensure they point to expected domains and use secure protocols. Default `HttpClient` behavior follows redirects, which can bypass initial URL validation if the remote server responds with a redirect to an internal IP.
+**Prevention:** To prevent SSRF when fetching resources from user-provided URLs, strictly validate that the URI uses HTTPS and a trusted host (e.g., `*.googleusercontent.com`, `*.googleapis.com`). Additionally, disable auto-redirects on the `HttpClient` (`new HttpClientHandler { AllowAutoRedirect = false }`) before invoking `GetAsync()`.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,11 +48,16 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
-            if (response.IsSuccessStatusCode)
+            if (Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) &&
+                uri.Scheme == Uri.UriSchemeHttps &&
+                (uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
             {
+                using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+                using var httpClient = new HttpClient(handler);
+                httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
+                var response = await httpClient.GetAsync(GooglePhotoUrl);
+                if (response.IsSuccessStatusCode)
+                {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();
                 var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
                 var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
@@ -61,6 +66,7 @@ public class CreateModel : PageModel
                 var filePath = Path.Combine(uploadsFolder, uniqueFileName);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
                 NewWhiskey.ImageFileName = uniqueFileName;
+                }
             }
         }
         else if (ImageUpload != null)

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,19 +62,24 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
-            if (response.IsSuccessStatusCode)
+            if (Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) &&
+                uri.Scheme == Uri.UriSchemeHttps &&
+                (uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
             {
-                var imageBytes = await response.Content.ReadAsByteArrayAsync();
+                using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+                using var httpClient = new HttpClient(handler);
+                httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
+                var response = await httpClient.GetAsync(GooglePhotoUrl);
+                if (response.IsSuccessStatusCode)
+                {
+                    var imageBytes = await response.Content.ReadAsByteArrayAsync();
                 var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
                 var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
                 var filePath = Path.Combine(uploadsFolder, uniqueFileName);
 
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
-                
+
                 if (!string.IsNullOrEmpty(Whiskey.ImageFileName))
                 {
                     var oldPath = Path.Combine(uploadsFolder, Whiskey.ImageFileName);
@@ -82,6 +87,7 @@ public class EditModel : PageModel
                 }
 
                 Whiskey.ImageFileName = uniqueFileName;
+                }
             }
         }
         else if (ImageUpload != null)

--- a/push.sh
+++ b/push.sh
@@ -1,0 +1,1 @@
+git push -u origin fix/ssrf-mitigation


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Server-Side Request Forgery (SSRF). The application fetched Google Photos images using a user-provided `GooglePhotoUrl` without validating the host, scheme, or restricting HTTP redirects. This could allow an attacker to make the server fetch resources from internal networks or arbitrary endpoints.
🎯 **Impact:** An attacker could trick the application into making HTTP requests to internal IP addresses or sensitive external services, potentially extracting metadata or mapping internal network infrastructure.
🔧 **Fix:** 
- Added strict URL validation using `Uri.TryCreate` enforcing the `https` scheme.
- Restricted allowed hostnames to `*.googleusercontent.com` and `*.googleapis.com`.
- Overrode default `HttpClient` auto-redirect behavior by passing an `HttpClientHandler` with `AllowAutoRedirect = false`.
✅ **Verification:** Verified by building and running the `dotnet test` test suite.

Note: Includes updates to the Sentinel journal (`.jules/sentinel.md`) explaining the vulnerability and fix.

---
*PR created automatically by Jules for task [14508523279098881982](https://jules.google.com/task/14508523279098881982) started by @whwar9739*