### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in image uploads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2025-02-23 - Missing SSRF Mitigations in Image Fetching
+**Vulnerability:** Fetching user-provided image URLs (`GooglePhotoUrl`) without validation or redirect prevention allowed for potential Server-Side Request Forgery (SSRF). An attacker could provide a malicious URL to scan internal network infrastructure or access sensitive internal endpoints.
+**Learning:** Even when intended for a specific service (e.g., Google Photos), `HttpClient.GetAsync` will gladly resolve and fetch from any internal or external host provided if not explicitly restricted.
+**Prevention:** Always validate user-provided URLs using `Uri.TryCreate` with `UriKind.Absolute`, enforce HTTPS (`Uri.UriSchemeHttps`), explicitly whitelist allowed hosts (e.g., `endsWith(".googleusercontent.com")`), and disable HTTP auto-redirects on the `HttpClientHandler` (`AllowAutoRedirect = false`).

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,19 +48,28 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
-            if (response.IsSuccessStatusCode)
+            // Validate the URL to prevent Server-Side Request Forgery (SSRF)
+            if (Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) &&
+                uri.Scheme == Uri.UriSchemeHttps &&
+                (uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
             {
+                // Disable auto-redirects to prevent redirect-based SSRF
+                var handler = new HttpClientHandler { AllowAutoRedirect = false };
+                using var httpClient = new HttpClient(handler);
+                httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
+                var response = await httpClient.GetAsync(uri);
+
+                if (response.IsSuccessStatusCode)
+                {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();
                 var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
                 var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
                 
-                var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-                await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
-                NewWhiskey.ImageFileName = uniqueFileName;
+                    var filePath = Path.Combine(uploadsFolder, uniqueFileName);
+                    await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
+                    NewWhiskey.ImageFileName = uniqueFileName;
+                }
             }
         }
         else if (ImageUpload != null)

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,26 +62,34 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
-            if (response.IsSuccessStatusCode)
+            // Validate the URL to prevent Server-Side Request Forgery (SSRF)
+            if (Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) &&
+                uri.Scheme == Uri.UriSchemeHttps &&
+                (uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
             {
-                var imageBytes = await response.Content.ReadAsByteArrayAsync();
-                var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
-                var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
-                var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-
-                if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
-                await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
-                
-                if (!string.IsNullOrEmpty(Whiskey.ImageFileName))
+                // Disable auto-redirects to prevent redirect-based SSRF
+                var handler = new HttpClientHandler { AllowAutoRedirect = false };
+                using var httpClient = new HttpClient(handler);
+                httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
+                var response = await httpClient.GetAsync(uri);
+                if (response.IsSuccessStatusCode)
                 {
-                    var oldPath = Path.Combine(uploadsFolder, Whiskey.ImageFileName);
-                    if (System.IO.File.Exists(oldPath)) System.IO.File.Delete(oldPath);
-                }
+                    var imageBytes = await response.Content.ReadAsByteArrayAsync();
+                    var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
+                    var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
+                    var filePath = Path.Combine(uploadsFolder, uniqueFileName);
 
-                Whiskey.ImageFileName = uniqueFileName;
+                    if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
+                    await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
+
+                    if (!string.IsNullOrEmpty(Whiskey.ImageFileName))
+                    {
+                        var oldPath = Path.Combine(uploadsFolder, Whiskey.ImageFileName);
+                        if (System.IO.File.Exists(oldPath)) System.IO.File.Delete(oldPath);
+                    }
+
+                    Whiskey.ImageFileName = uniqueFileName;
+                }
             }
         }
         else if (ImageUpload != null)


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unrestricted `HttpClient.GetAsync` fetches from user-provided `GooglePhotoUrl`, allowing for Server-Side Request Forgery (SSRF) and internal network scanning.
🎯 **Impact:** An attacker could provide malicious URLs to bypass firewalls and interact with internal network resources or sensitive internal endpoints.
🔧 **Fix:** Added absolute URL schema validation, enforced HTTPS, explicitly whitelisted `.googleusercontent.com` and `.googleapis.com` hostnames, and disabled `HttpClientHandler.AllowAutoRedirect` to prevent malicious redirect bypasses in both `Create.cshtml.cs` and `Edit.cshtml.cs`.
✅ **Verification:** Verify that providing valid Google Photos URLs still functions correctly during whiskey creation/editing, and that arbitrary/internal URLs (e.g., `http://localhost`, `http://169.254.169.254`) fail to process.

---
*PR created automatically by Jules for task [866933250582546129](https://jules.google.com/task/866933250582546129) started by @whwar9739*