### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerabilities in photo upload

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-24 - SSRF in Photo Upload via External URLs
+**Vulnerability:** The application fetched external images via `HttpClient.GetAsync(GooglePhotoUrl)` without validating the scheme, hostname, or restricting automatic redirects. This could allow an attacker to send requests to internal network services or malicious endpoints (SSRF).
+**Learning:** Instantiating `HttpClient` without proper URL sanitization and disabling auto-redirects (`AllowAutoRedirect = false`) exposes internal resources when handling user-provided URLs.
+**Prevention:** Always validate URLs using `Uri.TryCreate` with `UriKind.Absolute`, enforce `https`, restrict hosts to known safe domains (e.g., `*.googleusercontent.com`), and explicitly pass `new HttpClientHandler { AllowAutoRedirect = false }` to `HttpClient`.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,12 +48,17 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
-            if (response.IsSuccessStatusCode)
+            if (Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var parsedUri) &&
+                parsedUri.Scheme == Uri.UriSchemeHttps &&
+                (parsedUri.Host.EndsWith(".googleusercontent.com") || parsedUri.Host.EndsWith(".googleapis.com")))
             {
-                var imageBytes = await response.Content.ReadAsByteArrayAsync();
+                using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+                using var httpClient = new HttpClient(handler);
+                httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
+                var response = await httpClient.GetAsync(parsedUri);
+                if (response.IsSuccessStatusCode)
+                {
+                    var imageBytes = await response.Content.ReadAsByteArrayAsync();
                 var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
                 var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
@@ -61,6 +66,7 @@ public class CreateModel : PageModel
                 var filePath = Path.Combine(uploadsFolder, uniqueFileName);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
                 NewWhiskey.ImageFileName = uniqueFileName;
+                }
             }
         }
         else if (ImageUpload != null)

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,19 +62,24 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
-            if (response.IsSuccessStatusCode)
+            if (Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var parsedUri) &&
+                parsedUri.Scheme == Uri.UriSchemeHttps &&
+                (parsedUri.Host.EndsWith(".googleusercontent.com") || parsedUri.Host.EndsWith(".googleapis.com")))
             {
-                var imageBytes = await response.Content.ReadAsByteArrayAsync();
+                using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+                using var httpClient = new HttpClient(handler);
+                httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
+                var response = await httpClient.GetAsync(parsedUri);
+                if (response.IsSuccessStatusCode)
+                {
+                    var imageBytes = await response.Content.ReadAsByteArrayAsync();
                 var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
                 var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
                 var filePath = Path.Combine(uploadsFolder, uniqueFileName);
 
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
-                
+
                 if (!string.IsNullOrEmpty(Whiskey.ImageFileName))
                 {
                     var oldPath = Path.Combine(uploadsFolder, Whiskey.ImageFileName);
@@ -82,6 +87,7 @@ public class EditModel : PageModel
                 }
 
                 Whiskey.ImageFileName = uniqueFileName;
+                }
             }
         }
         else if (ImageUpload != null)

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,5 @@
+🚨 Severity: CRITICAL
+💡 Vulnerability: Server-Side Request Forgery (SSRF) when fetching user-provided Google Photo URLs in `Create.cshtml.cs` and `Edit.cshtml.cs`.
+🎯 Impact: Attackers could send unauthorized requests to internal network services or malicious endpoints via the application's backend.
+🔧 Fix: Validated URLs using `Uri.TryCreate` with `UriKind.Absolute`, enforced `https`, restricted valid hosts to `.googleusercontent.com` and `.googleapis.com`, and disabled auto-redirects on the `HttpClient` to prevent bypass.
+✅ Verification: Ran the full test suite (`dotnet test`), verifying compilation and functionality without regressions.


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Server-Side Request Forgery (SSRF) when fetching user-provided Google Photo URLs in `Create.cshtml.cs` and `Edit.cshtml.cs`.
🎯 Impact: Attackers could send unauthorized requests to internal network services or malicious endpoints via the application's backend.
🔧 Fix: Validated URLs using `Uri.TryCreate` with `UriKind.Absolute`, enforced `https`, restricted valid hosts to `.googleusercontent.com` and `.googleapis.com`, and disabled auto-redirects on the `HttpClient` to prevent bypass.
✅ Verification: Ran the full test suite (`dotnet test`), verifying compilation and functionality without regressions.

---
*PR created automatically by Jules for task [4143613011410838706](https://jules.google.com/task/4143613011410838706) started by @whwar9739*