### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photos integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+## 2026-06-23 - [SSRF in Image URL Fetching]
+**Vulnerability:** User-provided URLs for fetching images (e.g., Google Photos integration) were requested directly via HttpClient without validation, allowing Server-Side Request Forgery (SSRF) to internal services.
+**Learning:** External URLs provided by users must be strictly validated for the HTTPS scheme and trusted domain names. Furthermore, auto-redirects on HttpClient should be disabled to prevent redirection to internal/malicious endpoints after initial validation passes.
+**Prevention:** Use `Uri.TryCreate` to enforce `UriSchemeHttps` and a whitelist of trusted domains (e.g., `.googleusercontent.com`). Disable auto-redirects using `new HttpClientHandler { AllowAutoRedirect = false }`.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,9 +48,21 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            // SSRF Mitigation: Validate URL scheme and allowed hosts
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid or unauthorized image URL.");
+                return Page();
+            }
+
+            // SSRF Mitigation: Disable auto-redirects
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
+
+            var response = await httpClient.GetAsync(uri);
             if (response.IsSuccessStatusCode)
             {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,9 +62,21 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            // SSRF Mitigation: Validate URL scheme and allowed hosts
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid or unauthorized image URL.");
+                return Page();
+            }
+
+            // SSRF Mitigation: Disable auto-redirects
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
+
+            var response = await httpClient.GetAsync(uri);
             if (response.IsSuccessStatusCode)
             {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: User-provided URLs for Google Photos integration were requested directly via HttpClient without validation, allowing Server-Side Request Forgery (SSRF).
🎯 Impact: An attacker could force the server to make requests to internal services or malicious endpoints, potentially bypassing firewalls and accessing sensitive internal data.
🔧 Fix: Implemented strict URL validation using `Uri.TryCreate` to enforce HTTPS and whitelist trusted domains (`.googleusercontent.com`, `.googleapis.com`). Disabled auto-redirects on HttpClient to prevent redirection bypass.
✅ Verification: Ran `dotnet test` and verified the logic securely handles and rejects malicious URLs.

---
*PR created automatically by Jules for task [9407794489638043367](https://jules.google.com/task/9407794489638043367) started by @whwar9739*