### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photos Integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-24 - SSRF in Google Photos Integration
+**Vulnerability:** Server-Side Request Forgery (SSRF). The application used a user-provided URL (`GooglePhotoUrl`) directly in an `HttpClient.GetAsync` call without validating the scheme, host, or disabling auto-redirects. This allowed arbitrary requests to internal or external endpoints.
+**Learning:** External integrations relying on user-provided inputs must strictly validate the input to ensure it points to the intended service and prevent arbitrary request forwarding.
+**Prevention:** Validate user-provided URLs using `Uri.TryCreate` to enforce HTTPS and trusted hosts (e.g., `*.googleusercontent.com`, `*.googleapis.com`), and explicitly disable auto-redirects (`HttpClientHandler { AllowAutoRedirect = false }`) to stop redirection to internal/untrusted endpoints.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,19 +48,26 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
-            if (response.IsSuccessStatusCode)
+            // SSRF Mitigation: Validate URL and restrict to trusted Google Photos hosts
+            if (Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) &&
+                uri.Scheme == Uri.UriSchemeHttps &&
+                (uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
             {
+                var handler = new HttpClientHandler { AllowAutoRedirect = false };
+                using var httpClient = new HttpClient(handler);
+                httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
+                var response = await httpClient.GetAsync(uri);
+                if (response.IsSuccessStatusCode)
+                {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();
                 var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
                 var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
-                
+
                 var filePath = Path.Combine(uploadsFolder, uniqueFileName);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
                 NewWhiskey.ImageFileName = uniqueFileName;
+                }
             }
         }
         else if (ImageUpload != null)
@@ -74,7 +81,7 @@ public class CreateModel : PageModel
             }
 
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-            
+
             using (var fileStream = new FileStream(filePath, FileMode.Create))
             {
                 await ImageUpload.CopyToAsync(fileStream);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,11 +62,17 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
-            if (response.IsSuccessStatusCode)
+            // SSRF Mitigation: Validate URL and restrict to trusted Google Photos hosts
+            if (Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) &&
+                uri.Scheme == Uri.UriSchemeHttps &&
+                (uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
             {
+                var handler = new HttpClientHandler { AllowAutoRedirect = false };
+                using var httpClient = new HttpClient(handler);
+                httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
+                var response = await httpClient.GetAsync(uri);
+                if (response.IsSuccessStatusCode)
+                {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();
                 var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
                 var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
@@ -74,7 +80,7 @@ public class EditModel : PageModel
 
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
-                
+
                 if (!string.IsNullOrEmpty(Whiskey.ImageFileName))
                 {
                     var oldPath = Path.Combine(uploadsFolder, Whiskey.ImageFileName);
@@ -82,6 +88,7 @@ public class EditModel : PageModel
                 }
 
                 Whiskey.ImageFileName = uniqueFileName;
+                }
             }
         }
         else if (ImageUpload != null)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Server-Side Request Forgery (SSRF) when fetching images from user-provided URLs.
🎯 Impact: An attacker could force the server to make requests to arbitrary internal or external endpoints.
🔧 Fix: Validated that URLs use HTTPS and trusted Google hosts, and disabled auto-redirects on HttpClient.
✅ Verification: Ran unit tests and manually verified.

---
*PR created automatically by Jules for task [15927003059374985244](https://jules.google.com/task/15927003059374985244) started by @whwar9739*