### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in image upload

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-24 - SSRF in Google Photos Integration
+**Vulnerability:** The application was fetching images from user-provided URLs in `Create.cshtml.cs` and `Edit.cshtml.cs` without validating the host or scheme, allowing Server-Side Request Forgery (SSRF) attacks against internal services.
+**Learning:** `HttpClient.GetAsync` will happily fetch from local/internal IPs (e.g., `127.0.0.1`, `169.254.169.254`) or use non-HTTPS schemes if not explicitly restricted. Furthermore, `HttpClient` follows redirects by default, which can bypass initial URL validation if a malicious external server redirects to an internal one.
+**Prevention:** Always validate user-provided URLs (using `Uri.TryCreate` with `UriKind.Absolute`), enforce HTTPS, restrict the host to a trusted allowlist (e.g., `*.googleusercontent.com`), and explicitly disable auto-redirects on `HttpClient` (`AllowAutoRedirect = false`).

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,7 +48,17 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            // Security: Prevent SSRF by validating the URL before fetching it.
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError(string.Empty, "Invalid image URL.");
+                return Page();
+            }
+
+            var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,7 +62,17 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            // Security: Prevent SSRF by validating the URL before fetching it.
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError(string.Empty, "Invalid image URL.");
+                return Page();
+            }
+
+            var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Server-Side Request Forgery (SSRF) when downloading images from user-provided URLs in Create and Edit endpoints.
🎯 Impact: Attackers could force the server to make requests to internal services or bypass validation by redirecting to restricted endpoints.
🔧 Fix: Validated URLs strictly enforce HTTPS and trusted hosts (*.googleusercontent.com, *.googleapis.com). Additionally, disabled auto-redirects on HttpClient.
✅ Verification: Tested via 'dotnet test' and manual review that image uploads continue to work correctly while invalid URLs are rejected.

---
*PR created automatically by Jules for task [14007225103525174441](https://jules.google.com/task/14007225103525174441) started by @whwar9739*