### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photos integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-24 - SSRF in Google Photos Integration
+**Vulnerability:** The Google Photos integration used `HttpClient.GetAsync` on a user-provided URL (`GooglePhotoUrl`) in `Create.cshtml.cs` and `Edit.cshtml.cs` without validating the host, scheme, or disabling automatic redirects, which exposed the server to Server-Side Request Forgery (SSRF).
+**Learning:** External user input used directly in outbound HTTP requests must always be strictly validated and sanitized to prevent SSRF attacks.
+**Prevention:** Always validate URLs using `Uri.TryCreate` to enforce HTTPS and trusted hosts (e.g., `*.googleusercontent.com`), and explicitly disable auto-redirects on `HttpClientHandler` (`AllowAutoRedirect = false`).

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,7 +48,18 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            // SSRF Mitigation: Validate URL scheme and trusted hosts
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid or untrusted image URL.");
+                return Page();
+            }
+
+            // SSRF Mitigation: Disable auto-redirects
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,7 +62,18 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            // SSRF Mitigation: Validate URL scheme and trusted hosts
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid or untrusted image URL.");
+                return Page();
+            }
+
+            // SSRF Mitigation: Disable auto-redirects
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Server-Side Request Forgery (SSRF) allowed attackers to force the server to make requests to arbitrary internal or external URLs by providing an unverified `GooglePhotoUrl` during whiskey creation or editing.
🎯 Impact: Attackers could scan internal networks, access metadata services, or bypass firewalls to hit restricted endpoints.
🔧 Fix: Added strict validation using `Uri.TryCreate` to ensure the URL scheme is HTTPS and the host ends with trusted Google domains (`.googleusercontent.com` or `.googleapis.com`). Additionally configured the `HttpClientHandler` to explicitly disable automatic redirects (`AllowAutoRedirect = false`) as a defense-in-depth measure.
✅ Verification: Ran `dotnet build` and `dotnet test`. Examined the logic to ensure untrusted domains are correctly blocked with a validation error.

---
*PR created automatically by Jules for task [11360908515336465584](https://jules.google.com/task/11360908515336465584) started by @whwar9739*