### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photos Integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,11 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-07-01 - SSRF Prevention in Google Photos Integration
+**Vulnerability:** Server-Side Request Forgery (SSRF) was possible via the `GooglePhotoUrl` parameter during Whiskey creation and editing. The application used an unsanitized user-provided URL in an `HttpClient.GetAsync()` call and allowed automatic redirects, enabling attackers to make arbitrary requests to internal network resources or malicious external endpoints on behalf of the server.
+**Learning:** External integrations relying on user-provided URLs require strict validation and constrained HTTP client configuration to prevent SSRF, even if the primary intent is simply downloading an image.
+**Prevention:**
+1. Validate the URL structure (absolute URI, HTTPS scheme).
+2. Enforce an allowlist of trusted hosts (e.g., `*.googleusercontent.com`, `*.googleapis.com`).
+3. Disable automatic redirects on the `HttpClient` (`AllowAutoRedirect = false`) to prevent attackers from using an allowed host that redirects to a prohibited internal resource.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,7 +48,16 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photos URL.");
+                return Page();
+            }
+
+            using var httpClientHandler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(httpClientHandler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,7 +62,16 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photos URL.");
+                return Page();
+            }
+
+            using var httpClientHandler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(httpClientHandler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Server-Side Request Forgery (SSRF) was possible via the `GooglePhotoUrl` parameter during Whiskey creation and editing. The application used an unsanitized user-provided URL in an `HttpClient.GetAsync()` call and allowed automatic redirects.
🎯 Impact: Could be used to access internal network resources, conduct port scanning, or interact with sensitive internal endpoints.
🔧 Fix: 
1. Validated the URL structure (absolute URI, HTTPS scheme).
2. Enforced an allowlist of trusted hosts (`*.googleusercontent.com`, `*.googleapis.com`).
3. Disabled automatic redirects on the `HttpClient` (`AllowAutoRedirect = false`).
✅ Verification: Ran `dotnet test` to ensure no functionality is broken and verified that the SSRF mitigation is correctly implemented in both `Create.cshtml.cs` and `Edit.cshtml.cs`.

---
*PR created automatically by Jules for task [479508972907406593](https://jules.google.com/task/479508972907406593) started by @whwar9739*