### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photo URL Fetching

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-07-01 - SSRF Vulnerability in Google Photo URL Fetching
+**Vulnerability:** The application fetches image content directly from user-provided URLs in `GooglePhotoUrl` without validation, allowing a Server-Side Request Forgery (SSRF) attack.
+**Learning:** `HttpClient.GetAsync` blindly follows redirects and fetches URLs on any host by default.
+**Prevention:** Always validate user-provided URIs to enforce HTTPS, restrict to trusted hosts (like `*.googleusercontent.com`), and disable auto-redirects (`AllowAutoRedirect = false`) on the `HttpClientHandler`.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,9 +48,18 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError(string.Empty, "Invalid Google Photo URL.");
+                return Page();
+            }
+
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
+            var response = await httpClient.GetAsync(uri);
             if (response.IsSuccessStatusCode)
             {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,9 +62,18 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError(string.Empty, "Invalid Google Photo URL.");
+                return Page();
+            }
+
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
-            var response = await httpClient.GetAsync(GooglePhotoUrl);
+            var response = await httpClient.GetAsync(uri);
             if (response.IsSuccessStatusCode)
             {
                 var imageBytes = await response.Content.ReadAsByteArrayAsync();


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: SSRF vulnerability when fetching Google Photos URLs.
🎯 Impact: Attackers could scan internal networks or access internal endpoints.
🔧 Fix: Validated URIs to ensure HTTPS, restricted hosts to googleusercontent.com and googleapis.com, and disabled auto-redirects.
✅ Verification: Verify all tests pass with dotnet test.

---
*PR created automatically by Jules for task [2600852004249528744](https://jules.google.com/task/2600852004249528744) started by @whwar9739*