### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photos Integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-18 - SSRF Vulnerability in Google Photos Integration
+**Vulnerability:** The application was vulnerable to Server-Side Request Forgery (SSRF) when processing Google Photos image URLs in `Create.cshtml.cs` and `Edit.cshtml.cs`. The user-provided URL was directly passed to `HttpClient.GetAsync` without host validation or disabling automatic redirects, potentially allowing attackers to scan internal networks or access sensitive internal services.
+**Learning:** Never trust user-provided URLs when making server-side HTTP requests, even if they appear to originate from a known feature (like Google Photos). Automatic HTTP redirects can bypass initial URL validation checks if not explicitly disabled.
+**Prevention:** Strictly validate that the URI uses HTTPS and a trusted host (e.g., `*.googleusercontent.com` or `*.googleapis.com`) using `Uri.TryCreate` with `UriKind.Absolute`. Disable automatic redirects on the `HttpClient` (`new HttpClientHandler { AllowAutoRedirect = false }`) to ensure the request only goes to the validated host.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,7 +48,17 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            // Prevent Server-Side Request Forgery (SSRF)
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photos URL.");
+                return Page();
+            }
+
+            var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,7 +62,17 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            // Prevent Server-Side Request Forgery (SSRF)
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photos URL.");
+                return Page();
+            }
+
+            var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Server-Side Request Forgery (SSRF) when processing Google Photos image URLs in Whiskey creation and editing.
🎯 Impact: Attackers could potentially scan internal networks or access sensitive internal services by providing malicious URLs.
🔧 Fix: Validated that the URI uses HTTPS and a trusted host (*.googleusercontent.com or *.googleapis.com). Disabled automatic redirects on HttpClient.
✅ Verification: Code logic reviewed to ensure only valid endpoints are accessed and automatic redirects are prohibited.

---
*PR created automatically by Jules for task [8646356864010586143](https://jules.google.com/task/8646356864010586143) started by @whwar9739*