### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photos Integration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-24 - SSRF Vulnerability in Google Photos Integration
+**Vulnerability:** The application fetched Google Photos images from user-supplied URLs (`GooglePhotoUrl`) without any URL validation or restriction on auto-redirects. An attacker could exploit this Server-Side Request Forgery (SSRF) vulnerability to make the server fetch internal network resources or unintended external endpoints by supplying a malicious URL or a URL that redirects to internal resources.
+**Learning:** Instantiating `HttpClient` without custom handlers defaults to following redirects. When dealing with user-supplied URLs intended for specific trusted services (like Google Photos), the URL must be strictly validated.
+**Prevention:** Validate user-supplied URLs to ensure they use the `https` scheme and resolve to expected trusted hosts (e.g., `*.googleusercontent.com` or `*.googleapis.com`). Additionally, configure the `HttpClient` using `new HttpClientHandler { AllowAutoRedirect = false }` to prevent attackers from using open redirects to bypass host validation.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,7 +48,16 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError(string.Empty, "Invalid Google Photo URL.");
+                return Page();
+            }
+
+            var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,7 +62,16 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                !(uri.Host.EndsWith(".googleusercontent.com") || uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError(string.Empty, "Invalid Google Photo URL.");
+                return Page();
+            }
+
+            var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Server-Side Request Forgery (SSRF) when fetching Google Photos via user-supplied URLs
🎯 Impact: Attackers could make the server issue GET requests to arbitrary internal or external endpoints, bypassing firewalls
🔧 Fix: Added URL validation (https + trusted host) and disabled auto-redirects in HttpClient
✅ Verification: Ensure tests pass and the image fetch logic correctly blocks invalid host URLs.

---
*PR created automatically by Jules for task [13560948672993996168](https://jules.google.com/task/13560948672993996168) started by @whwar9739*