### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Server-Side Request Forgery (SSRF)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-04-16 - Unmitigated Server-Side Request Forgery (SSRF) in Photo Integration
+**Vulnerability:** The application accepted a user-provided URL (`GooglePhotoUrl`) during whiskey creation and editing, fetching the content using an unconstrained `HttpClient.GetAsync()`. This allowed an attacker to supply internal or non-HTTPS URLs, potentially causing the server to make requests to unintended internal services (SSRF).
+**Learning:** `HttpClient.GetAsync()` will automatically follow redirects and make requests to any scheme/host provided if not explicitly restricted. User-supplied URLs intended for specific external integrations must be tightly validated against an expected list of hosts.
+**Prevention:** To prevent SSRF, use `Uri.TryCreate(url, UriKind.Absolute)` to validate the URL format and scheme (HTTPS only), restrict the `Host` to trusted domains (e.g., `*.googleusercontent.com`, `*.googleapis.com`), and instantiate the `HttpClient` with an `HttpClientHandler` configured with `AllowAutoRedirect = false`.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,7 +48,19 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            // Security: SSRF Mitigation - Validate URL is HTTPS and points to allowed Google domains
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uriResult) ||
+                uriResult.Scheme != Uri.UriSchemeHttps ||
+                (!uriResult.Host.EndsWith(".googleusercontent.com") && !uriResult.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL.");
+                return Page();
+            }
+
+            // Security: SSRF Mitigation - Disable auto-redirects
+            using var httpClientHandler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(httpClientHandler);
+
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)
@@ -57,7 +69,7 @@ public class CreateModel : PageModel
                 var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
                 var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
-                
+
                 var filePath = Path.Combine(uploadsFolder, uniqueFileName);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
                 NewWhiskey.ImageFileName = uniqueFileName;
@@ -74,7 +86,7 @@ public class CreateModel : PageModel
             }
 
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-            
+
             using (var fileStream = new FileStream(filePath, FileMode.Create))
             {
                 await ImageUpload.CopyToAsync(fileStream);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,7 +62,19 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            // Security: SSRF Mitigation - Validate URL is HTTPS and points to allowed Google domains
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uriResult) ||
+                uriResult.Scheme != Uri.UriSchemeHttps ||
+                (!uriResult.Host.EndsWith(".googleusercontent.com") && !uriResult.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid Google Photo URL.");
+                return Page();
+            }
+
+            // Security: SSRF Mitigation - Disable auto-redirects
+            using var httpClientHandler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(httpClientHandler);
+
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)
@@ -74,7 +86,7 @@ public class EditModel : PageModel
 
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
-                
+
                 if (!string.IsNullOrEmpty(Whiskey.ImageFileName))
                 {
                     var oldPath = Path.Combine(uploadsFolder, Whiskey.ImageFileName);

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,5 @@
+🚨 Severity: CRITICAL
+💡 Vulnerability: Server-Side Request Forgery (SSRF) when fetching Google Photo URLs via unconstrained HttpClient.GetAsync().
+🎯 Impact: Attackers could provide internal URLs or other unapproved locations, causing the server to fetch unauthorized resources.
+🔧 Fix: Added strict HTTPS verification, domain checking (only allowing googleusercontent.com and googleapis.com), and disabled auto-redirects.
+✅ Verification: Ran dotnet test and verified that tests still pass.


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Server-Side Request Forgery (SSRF) when fetching Google Photo URLs via unconstrained HttpClient.GetAsync().
🎯 Impact: Attackers could provide internal URLs or other unapproved locations, causing the server to fetch unauthorized resources.
🔧 Fix: Added strict HTTPS verification, domain checking (only allowing googleusercontent.com and googleapis.com), and disabled auto-redirects.
✅ Verification: Ran dotnet test and verified that tests still pass.

---
*PR created automatically by Jules for task [12697910125510951134](https://jules.google.com/task/12697910125510951134) started by @whwar9739*