### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photo URL fetch

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-15 - SSRF Vulnerability in Google Photo URL Fetch
+**Vulnerability:** The `Create.cshtml.cs` and `Edit.cshtml.cs` files fetched user-provided Google Photo URLs using `HttpClient.GetAsync` without any validation or sanitization, creating a Server-Side Request Forgery (SSRF) vulnerability. An attacker could potentially pass internal network addresses or arbitrary external URLs.
+**Learning:** Even when integrating with third-party APIs (like Google Photos), any URL provided by the client must be rigorously validated before the server initiates a request to it.
+**Prevention:** Always validate user-provided URLs using `Uri.TryCreate` with `UriKind.Absolute`, enforce a strict scheme allowlist (e.g., `Uri.UriSchemeHttps`), explicitly check the `Host` property against a trusted allowlist (e.g., `*.googleusercontent.com` and `*.googleapis.com`), and disable automatic redirects (`AllowAutoRedirect = false`) on the `HttpClientHandler` to prevent the server from being coerced into following redirects to arbitrary locations.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,7 +48,16 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                (!uri.Host.EndsWith(".googleusercontent.com") && !uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError(string.Empty, "Invalid image URL.");
+                return Page();
+            }
+
+            var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)
@@ -57,7 +66,7 @@ public class CreateModel : PageModel
                 var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
                 var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
-                
+
                 var filePath = Path.Combine(uploadsFolder, uniqueFileName);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
                 NewWhiskey.ImageFileName = uniqueFileName;
@@ -74,7 +83,7 @@ public class CreateModel : PageModel
             }
 
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-            
+
             using (var fileStream = new FileStream(filePath, FileMode.Create))
             {
                 await ImageUpload.CopyToAsync(fileStream);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,7 +62,16 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                (!uri.Host.EndsWith(".googleusercontent.com") && !uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError(string.Empty, "Invalid image URL.");
+                return Page();
+            }
+
+            var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)
@@ -74,7 +83,7 @@ public class EditModel : PageModel
 
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
-                
+
                 if (!string.IsNullOrEmpty(Whiskey.ImageFileName))
                 {
                     var oldPath = Path.Combine(uploadsFolder, Whiskey.ImageFileName);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `Create.cshtml.cs` and `Edit.cshtml.cs` files fetch user-provided Google Photo URLs using `HttpClient.GetAsync` without any validation or sanitization, creating a Server-Side Request Forgery (SSRF) vulnerability. An attacker could potentially pass internal network addresses or arbitrary external URLs.
🎯 Impact: This could allow an attacker to probe internal networks, read local files, or force the server to interact with unintended endpoints.
🔧 Fix: Validated user-provided URLs using `Uri.TryCreate` with `UriKind.Absolute`, enforced a strict scheme allowlist (`Uri.UriSchemeHttps`), explicitly checked the `Host` property against a trusted allowlist (`*.googleusercontent.com` and `*.googleapis.com`), and disabled automatic redirects (`AllowAutoRedirect = false`) on the `HttpClientHandler`.
✅ Verification: Ran `dotnet test` and confirmed all unit tests pass. Manual testing can be done by attempting to submit a local URL (e.g. `http://localhost`) in the Google Photo URL field, which will result in an "Invalid image URL" validation error.

---
*PR created automatically by Jules for task [12656543668109880085](https://jules.google.com/task/12656543668109880085) started by @whwar9739*