### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in Google Photos Fetch

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,12 @@
 **Vulnerability:** Any authenticated user could create, edit, or delete entries in the master `Whiskey` global directory because `Create.cshtml.cs`, `Edit.cshtml.cs`, and `Delete.cshtml.cs` under `Pages/Whiskies` lacked authorization attributes. Only the `/Admin` folder was protected by convention.
 **Learning:** Razor Pages convention-based folder authorization (`AuthorizeFolder("/Admin")`) does not automatically protect administrative-level entities that reside outside the designated admin folder.
 **Prevention:** Always explicitly annotate page models with `[Authorize(Roles = "Admin")]` for global entity modification pages, regardless of folder structure.
+
+## 2024-05-18 - SSRF Vulnerability in Google Photos Integration
+**Vulnerability:** The application fetches images from user-provided URLs (`GooglePhotoUrl`) via `HttpClient.GetAsync()` without validating the URL scheme, host, or disabling automatic redirects in `Create.cshtml.cs` and `Edit.cshtml.cs`. This allows Server-Side Request Forgery (SSRF), where an attacker could provide URLs to internal services or localhost.
+**Learning:** Any user-provided URL fetched by the server must be strictly validated. Relying on the frontend to provide a "Google Photos" URL is insufficient. `HttpClient` follows redirects by default, which can be used to bypass initial URL validation if not disabled.
+**Prevention:**
+1. Use `Uri.TryCreate` with `UriKind.Absolute` to parse and validate the URL.
+2. Ensure the `Scheme` is exactly `UriSchemeHttps`.
+3. Validate the `Host` against a strict allowlist (e.g., `*.googleusercontent.com` and `*.googleapis.com`).
+4. Disable auto-redirects when instantiating `HttpClient` by using `new HttpClientHandler { AllowAutoRedirect = false }` to prevent redirect-based SSRF.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -48,7 +48,18 @@ public class CreateModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            // SSRF Mitigation: Validate URL scheme and host
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                (!uri.Host.EndsWith(".googleusercontent.com") && !uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid image URL. Only Google Photos URLs are allowed.");
+                return Page();
+            }
+
+            // SSRF Mitigation: Disable auto-redirects
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -62,7 +62,18 @@ public class EditModel : PageModel
 
         if (!string.IsNullOrEmpty(GooglePhotoUrl) && !string.IsNullOrEmpty(GooglePhotoToken))
         {
-            using var httpClient = new HttpClient();
+            // SSRF Mitigation: Validate URL scheme and host
+            if (!Uri.TryCreate(GooglePhotoUrl, UriKind.Absolute, out var uri) ||
+                uri.Scheme != Uri.UriSchemeHttps ||
+                (!uri.Host.EndsWith(".googleusercontent.com") && !uri.Host.EndsWith(".googleapis.com")))
+            {
+                ModelState.AddModelError("GooglePhotoUrl", "Invalid image URL. Only Google Photos URLs are allowed.");
+                return Page();
+            }
+
+            // SSRF Mitigation: Disable auto-redirects
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Server-Side Request Forgery (SSRF) risk when fetching user-provided Google Photos URLs. 
🎯 Impact: Attackers could provide internal URLs (e.g., localhost or internal network endpoints) to access internal services or bypass firewalls.
🔧 Fix: Added strict URL validation (HTTPS only, trusted Google hosts only) and disabled auto-redirects on the HttpClient.
✅ Verification: Tested the endpoints to ensure they only fetch from the allowlisted Google domains.

---
*PR created automatically by Jules for task [12869555602293057154](https://jules.google.com/task/12869555602293057154) started by @whwar9739*