### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF and Path Traversal

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,13 @@
 **Vulnerability:** The application allowed users to provide a `GooglePhotoUrl` that was passed directly to `HttpClient.GetAsync()` without any validation in `Create.cshtml.cs` and `Edit.cshtml.cs`. This could allow an attacker to make the server send arbitrary HTTP requests to internal or external systems.
 **Learning:** External URLs provided by users must be strictly validated before being used in server-side HTTP requests to prevent SSRF vulnerabilities.
 **Prevention:** Use `Uri.TryCreate` with `UriKind.Absolute` to validate the URL format, enforce HTTPS (`Uri.UriSchemeHttps`), and restrict the host to an allowlist of trusted domains (e.g., `.googleusercontent.com`, `.googleapis.com`).
+
+## 2024-05-18 - Path Traversal via Image Upload
+**Vulnerability:** The image upload logic concatenated the user-supplied `ImageUpload.FileName` directly into the final `uniqueFileName` (`Guid.NewGuid().ToString() + "_" + ImageUpload.FileName`). An attacker could supply a filename with directory traversal characters (e.g., `../../malicious.exe`) potentially leading to arbitrary file write.
+**Learning:** Never trust the user-supplied filename when saving uploaded files to disk.
+**Prevention:** Generate a fully unique and secure filename on the server (like a `Guid`), and extract only the extension from the user's file (using `Path.GetExtension()`) to append it securely.
+
+## 2024-05-18 - SSRF Redirect Bypass
+**Vulnerability:** Even when URL inputs (like `GooglePhotoUrl`) are restricted by an allowlist, if the `HttpClient` allows automatic redirection, an attacker can provide an allowed URL that redirects to an internal endpoint (e.g., `http://169.254.169.254/latest/meta-data/`).
+**Learning:** A URL allowlist check is insufficient against SSRF if the HTTP client automatically follows redirects.
+**Prevention:** When making outbound HTTP requests to user-supplied URLs, disable auto-redirects by setting `AllowAutoRedirect = false` on the `HttpClientHandler` to ensure the request is not routed elsewhere.

--- a/WhiskeyTracker.Tests/WhiskiesTests.cs
+++ b/WhiskeyTracker.Tests/WhiskiesTests.cs
@@ -44,7 +44,7 @@ public class WhiskiesTests : TestBase
         await context.SaveChangesAsync();
 
         var legacyService = new WhiskeyTracker.Web.Services.LegacyMigrationService(context);
-        
+
         // Search matches Brand
         var pageModel = new IndexModel(context, legacyService) { SearchString = "William" };
         SetMockUser(pageModel, "test-user");
@@ -126,7 +126,7 @@ public class WhiskiesTests : TestBase
         Assert.IsType<RedirectToPageResult>(result);
         var whiskey = await context.Whiskies.FirstAsync();
         Assert.Equal("Test Whiskey", whiskey.Name);
-        Assert.Contains("test.jpg", whiskey.ImageFileName); // Confirms filename was generated
+        Assert.EndsWith(".jpg", whiskey.ImageFileName); // Confirms filename extension was preserved
     }
 
     [Fact]
@@ -140,8 +140,8 @@ public class WhiskiesTests : TestBase
 
         var pageModel = new CreateModel(context, mockEnv.Object)
         {
-            NewWhiskey = new Whiskey 
-            { 
+            NewWhiskey = new Whiskey
+            {
                 Name = "No Cask Whiskey",
                 Distillery = "Test Distillery",
                 CaskType = null // Explicitly null
@@ -477,7 +477,7 @@ public class WhiskiesTests : TestBase
         Assert.NotNull(updatedWhiskey);
         Assert.NotNull(updatedWhiskey.ImageFileName);
         Assert.NotEqual(oldFileName, updatedWhiskey.ImageFileName);
-        Assert.Contains(newFileName, updatedWhiskey.ImageFileName);
+        Assert.EndsWith(".jpg", updatedWhiskey.ImageFileName);
         Assert.False(File.Exists(oldFilePath));
         Assert.True(File.Exists(Path.Combine(tempPath, "images", updatedWhiskey.ImageFileName)));
 

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -56,7 +56,8 @@ public class CreateModel : PageModel
                 return Page();
             }
 
-            using var httpClient = new HttpClient();
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)
@@ -65,7 +66,7 @@ public class CreateModel : PageModel
                 var uniqueFileName = Guid.NewGuid().ToString() + ".jpg";
                 var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
-                
+
                 var filePath = Path.Combine(uploadsFolder, uniqueFileName);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
                 NewWhiskey.ImageFileName = uniqueFileName;
@@ -73,7 +74,7 @@ public class CreateModel : PageModel
         }
         else if (ImageUpload != null)
         {
-            var uniqueFileName = Guid.NewGuid().ToString() + "_" + ImageUpload.FileName;
+            var uniqueFileName = Guid.NewGuid().ToString() + Path.GetExtension(ImageUpload.FileName);
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
 
             if (!Directory.Exists(uploadsFolder))
@@ -82,7 +83,7 @@ public class CreateModel : PageModel
             }
 
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
-            
+
             using (var fileStream = new FileStream(filePath, FileMode.Create))
             {
                 await ImageUpload.CopyToAsync(fileStream);

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -70,7 +70,8 @@ public class EditModel : PageModel
                 return Page();
             }
 
-            using var httpClient = new HttpClient();
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)
@@ -82,7 +83,7 @@ public class EditModel : PageModel
 
                 if (!Directory.Exists(uploadsFolder)) Directory.CreateDirectory(uploadsFolder);
                 await System.IO.File.WriteAllBytesAsync(filePath, imageBytes);
-                
+
                 if (!string.IsNullOrEmpty(Whiskey.ImageFileName))
                 {
                     var oldPath = Path.Combine(uploadsFolder, Whiskey.ImageFileName);
@@ -94,7 +95,7 @@ public class EditModel : PageModel
         }
         else if (ImageUpload != null)
         {
-            var uniqueFileName = Guid.NewGuid().ToString() + "_" + ImageUpload.FileName;
+            var uniqueFileName = Guid.NewGuid().ToString() + Path.GetExtension(ImageUpload.FileName);
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application was vulnerable to SSRF because GooglePhotoUrl input was fetched using an HttpClient that followed redirects. Furthermore, it was vulnerable to Path Traversal during file upload because the raw ImageUpload.FileName was concatenated directly to the file path.
🎯 Impact: Attackers could bypass URL allowlists via open redirects to reach internal cloud metadata endpoints, and write arbitrary files to the disk by exploiting path traversal.
🔧 Fix: Configured HttpClient to prevent auto-redirects (`AllowAutoRedirect = false`) and switched to `Path.GetExtension(ImageUpload.FileName)` to securely append file extensions. Updated tests.
✅ Verification: Tested via `dotnet test` which passed 81 out of 81 tests successfully.

---
*PR created automatically by Jules for task [17075368456325050187](https://jules.google.com/task/17075368456325050187) started by @whwar9739*