### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Image Uploads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The application allowed users to provide a `GooglePhotoUrl` that was passed directly to `HttpClient.GetAsync()` without any validation in `Create.cshtml.cs` and `Edit.cshtml.cs`. This could allow an attacker to make the server send arbitrary HTTP requests to internal or external systems.
 **Learning:** External URLs provided by users must be strictly validated before being used in server-side HTTP requests to prevent SSRF vulnerabilities.
 **Prevention:** Use `Uri.TryCreate` with `UriKind.Absolute` to validate the URL format, enforce HTTPS (`Uri.UriSchemeHttps`), and restrict the host to an allowlist of trusted domains (e.g., `.googleusercontent.com`, `.googleapis.com`).
+
+## 2024-05-24 - Path Traversal in Image Uploads
+**Vulnerability:** The application appended the user-provided `ImageUpload.FileName` directly to a generated GUID when saving uploaded images in `Create.cshtml.cs` and `Edit.cshtml.cs` (e.g., `Guid.NewGuid().ToString() + "_" + ImageUpload.FileName`). An attacker could provide a filename like `../../../etc/passwd` to perform a path traversal attack.
+**Learning:** Never trust the `FileName` property of uploaded files directly, as it is user-controlled input and can contain path traversal characters.
+**Prevention:** Only extract the extension from the uploaded file using `Path.GetExtension(ImageUpload.FileName)` and append it to a newly generated GUID to construct a safe, unique filename.

--- a/WhiskeyTracker.Tests/WhiskiesTests.cs
+++ b/WhiskeyTracker.Tests/WhiskiesTests.cs
@@ -126,7 +126,7 @@ public class WhiskiesTests : TestBase
         Assert.IsType<RedirectToPageResult>(result);
         var whiskey = await context.Whiskies.FirstAsync();
         Assert.Equal("Test Whiskey", whiskey.Name);
-        Assert.Contains("test.jpg", whiskey.ImageFileName); // Confirms filename was generated
+        Assert.EndsWith(".jpg", whiskey.ImageFileName); // Confirms filename was generated
     }
 
     [Fact]
@@ -477,7 +477,7 @@ public class WhiskiesTests : TestBase
         Assert.NotNull(updatedWhiskey);
         Assert.NotNull(updatedWhiskey.ImageFileName);
         Assert.NotEqual(oldFileName, updatedWhiskey.ImageFileName);
-        Assert.Contains(newFileName, updatedWhiskey.ImageFileName);
+        Assert.EndsWith(".jpg", updatedWhiskey.ImageFileName);
         Assert.False(File.Exists(oldFilePath));
         Assert.True(File.Exists(Path.Combine(tempPath, "images", updatedWhiskey.ImageFileName)));
 

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -73,7 +73,7 @@ public class CreateModel : PageModel
         }
         else if (ImageUpload != null)
         {
-            var uniqueFileName = Guid.NewGuid().ToString() + "_" + ImageUpload.FileName;
+            var uniqueFileName = Guid.NewGuid().ToString() + Path.GetExtension(ImageUpload.FileName);
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
 
             if (!Directory.Exists(uploadsFolder))

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -94,7 +94,7 @@ public class EditModel : PageModel
         }
         else if (ImageUpload != null)
         {
-            var uniqueFileName = Guid.NewGuid().ToString() + "_" + ImageUpload.FileName;
+            var uniqueFileName = Guid.NewGuid().ToString() + Path.GetExtension(ImageUpload.FileName);
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
 


### PR DESCRIPTION
🚨 Severity: CRITICAL

💡 Vulnerability: User-provided filenames from image uploads were being appended to a GUID without sanitization (e.g., `Guid.NewGuid().ToString() + "_" + ImageUpload.FileName`), which allowed for path traversal attacks.

🎯 Impact: An attacker could use a filename like `../../../etc/passwd` to write files to arbitrary locations on the server file system.

🔧 Fix: Modified the upload logic in `Create.cshtml.cs` and `Edit.cshtml.cs` to only extract the file extension using `Path.GetExtension(ImageUpload.FileName)`.

✅ Verification: Run `dotnet test` to ensure tests still pass, specifically the `WhiskiesTests.cs` which validates the correct saving of filenames.

---
*PR created automatically by Jules for task [7886109340592184190](https://jules.google.com/task/7886109340592184190) started by @whwar9739*