### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF Bypass via Auto-Redirects

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The application allowed users to provide a `GooglePhotoUrl` that was passed directly to `HttpClient.GetAsync()` without any validation in `Create.cshtml.cs` and `Edit.cshtml.cs`. This could allow an attacker to make the server send arbitrary HTTP requests to internal or external systems.
 **Learning:** External URLs provided by users must be strictly validated before being used in server-side HTTP requests to prevent SSRF vulnerabilities.
 **Prevention:** Use `Uri.TryCreate` with `UriKind.Absolute` to validate the URL format, enforce HTTPS (`Uri.UriSchemeHttps`), and restrict the host to an allowlist of trusted domains (e.g., `.googleusercontent.com`, `.googleapis.com`).
+
+## 2026-08-07 - SSRF Bypass via HttpClient Auto-Redirects
+**Vulnerability:** Despite validating the scheme and host of `GooglePhotoUrl` before use, the `HttpClient` default configuration allowed auto-redirects. An attacker could supply a URL to a trusted domain that redirects to an internal or unauthorized resource, bypassing the initial validation and leading to Server-Side Request Forgery (SSRF).
+**Learning:** URL validation at the entry point is insufficient if the HTTP client automatically follows redirects to potentially unvalidated or untrusted destinations.
+**Prevention:** Always explicitly disable auto-redirects (`new HttpClientHandler { AllowAutoRedirect = false }`) when using `HttpClient` to fetch user-provided URLs.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -56,7 +56,8 @@ public class CreateModel : PageModel
                 return Page();
             }
 
-            using var httpClient = new HttpClient();
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -70,7 +70,8 @@ public class EditModel : PageModel
                 return Page();
             }
 
-            using var httpClient = new HttpClient();
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,5 @@
+🚨 Severity: CRITICAL
+💡 Vulnerability: SSRF via HTTP Auto-Redirects. Despite URL format and host validation, the default HttpClient allows auto-redirects. An attacker could supply a URL pointing to a trusted domain that redirects to an unauthorized internal or external resource, bypassing the check.
+🎯 Impact: This allows Server-Side Request Forgery (SSRF) where the server fetches arbitrary unintended URLs, potentially exposing internal services or aiding in reconnaissance.
+🔧 Fix: Explicitly disabled `AllowAutoRedirect` on the `HttpClient` used to fetch the user-provided Google Photos URL in `Create.cshtml.cs` and `Edit.cshtml.cs`.
+✅ Verification: Ensure the test suite passes, verify that providing an external URL that redirects is not followed, and confirm standard valid URLs work as expected.


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: SSRF via HTTP Auto-Redirects. Despite URL format and host validation, the default HttpClient allows auto-redirects. An attacker could supply a URL pointing to a trusted domain that redirects to an unauthorized internal or external resource, bypassing the check.
🎯 Impact: This allows Server-Side Request Forgery (SSRF) where the server fetches arbitrary unintended URLs, potentially exposing internal services or aiding in reconnaissance.
🔧 Fix: Explicitly disabled `AllowAutoRedirect` on the `HttpClient` used to fetch the user-provided Google Photos URL in `Create.cshtml.cs` and `Edit.cshtml.cs`.
✅ Verification: Ensure the test suite passes, verify that providing an external URL that redirects is not followed, and confirm standard valid URLs work as expected.

---
*PR created automatically by Jules for task [10236430065703901413](https://jules.google.com/task/10236430065703901413) started by @whwar9739*