### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF and Path Traversal in image uploads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The application allowed users to provide a `GooglePhotoUrl` that was passed directly to `HttpClient.GetAsync()` without any validation in `Create.cshtml.cs` and `Edit.cshtml.cs`. This could allow an attacker to make the server send arbitrary HTTP requests to internal or external systems.
 **Learning:** External URLs provided by users must be strictly validated before being used in server-side HTTP requests to prevent SSRF vulnerabilities.
 **Prevention:** Use `Uri.TryCreate` with `UriKind.Absolute` to validate the URL format, enforce HTTPS (`Uri.UriSchemeHttps`), and restrict the host to an allowlist of trusted domains (e.g., `.googleusercontent.com`, `.googleapis.com`).
+
+## 2024-11-20 - Path Traversal in Image Upload
+**Vulnerability:** The application blindly concatenated a GUID with `ImageUpload.FileName` without sanitization. An attacker could provide a filename like `../../etc/passwd` which would resolve outside the `images` directory.
+**Learning:** The built-in ASP.NET Core `IFormFile.FileName` is unsafe and retains the client-provided path or name, allowing path traversal if used directly in file system operations.
+**Prevention:** Always generate a completely new, safe filename server-side (like a GUID) and only preserve the file extension from the user-provided filename using `Path.GetExtension()`.

--- a/WhiskeyTracker.Tests/WhiskiesTests.cs
+++ b/WhiskeyTracker.Tests/WhiskiesTests.cs
@@ -126,7 +126,7 @@ public class WhiskiesTests : TestBase
         Assert.IsType<RedirectToPageResult>(result);
         var whiskey = await context.Whiskies.FirstAsync();
         Assert.Equal("Test Whiskey", whiskey.Name);
-        Assert.Contains("test.jpg", whiskey.ImageFileName); // Confirms filename was generated
+        Assert.True(whiskey.ImageFileName.EndsWith(".jpg")); // Confirms filename was generated
     }
 
     [Fact]
@@ -477,7 +477,7 @@ public class WhiskiesTests : TestBase
         Assert.NotNull(updatedWhiskey);
         Assert.NotNull(updatedWhiskey.ImageFileName);
         Assert.NotEqual(oldFileName, updatedWhiskey.ImageFileName);
-        Assert.Contains(newFileName, updatedWhiskey.ImageFileName);
+        Assert.True(updatedWhiskey.ImageFileName.EndsWith(".jpg"));
         Assert.False(File.Exists(oldFilePath));
         Assert.True(File.Exists(Path.Combine(tempPath, "images", updatedWhiskey.ImageFileName)));
 

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -56,7 +56,8 @@ public class CreateModel : PageModel
                 return Page();
             }
 
-            using var httpClient = new HttpClient();
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)
@@ -73,7 +74,8 @@ public class CreateModel : PageModel
         }
         else if (ImageUpload != null)
         {
-            var uniqueFileName = Guid.NewGuid().ToString() + "_" + ImageUpload.FileName;
+            var extension = Path.GetExtension(ImageUpload.FileName);
+            var uniqueFileName = Guid.NewGuid().ToString() + extension;
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
 
             if (!Directory.Exists(uploadsFolder))

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -70,7 +70,8 @@ public class EditModel : PageModel
                 return Page();
             }
 
-            using var httpClient = new HttpClient();
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)
@@ -94,7 +95,8 @@ public class EditModel : PageModel
         }
         else if (ImageUpload != null)
         {
-            var uniqueFileName = Guid.NewGuid().ToString() + "_" + ImageUpload.FileName;
+            var extension = Path.GetExtension(ImageUpload.FileName);
+            var uniqueFileName = Guid.NewGuid().ToString() + extension;
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "images");
             var filePath = Path.Combine(uploadsFolder, uniqueFileName);
 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix SSRF and Path Traversal in image uploads

Severity: CRITICAL
Vulnerability: Path Traversal in file uploads and SSRF in URL fetches
Impact: Remote Code Execution via arbitrary file writes and Internal network pivoting via SSRF
Fix: Used Path.GetExtension for filenames and AllowAutoRedirect=false for HttpClient
Verification: Ensure file uploads only keep extension and HttpClient rejects redirects

---
*PR created automatically by Jules for task [4407837395566202268](https://jules.google.com/task/4407837395566202268) started by @whwar9739*