### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in HttpClient auto-redirects

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The application allowed users to provide a `GooglePhotoUrl` that was passed directly to `HttpClient.GetAsync()` without any validation in `Create.cshtml.cs` and `Edit.cshtml.cs`. This could allow an attacker to make the server send arbitrary HTTP requests to internal or external systems.
 **Learning:** External URLs provided by users must be strictly validated before being used in server-side HTTP requests to prevent SSRF vulnerabilities.
 **Prevention:** Use `Uri.TryCreate` with `UriKind.Absolute` to validate the URL format, enforce HTTPS (`Uri.UriSchemeHttps`), and restrict the host to an allowlist of trusted domains (e.g., `.googleusercontent.com`, `.googleapis.com`).
+
+## 2024-05-18 - Server-Side Request Forgery (SSRF) in Image Upload via Redirects
+**Vulnerability:** The application mitigated SSRF by checking the host of a user-provided `GooglePhotoUrl` before passing it to `HttpClient.GetAsync()`. However, `HttpClient` automatically follows HTTP redirects by default. An attacker could supply a URL pointing to an allowed domain (e.g., via an open redirect vulnerability on `googleusercontent.com`) that then redirects to an internal server or IP address, bypassing the initial host validation.
+**Learning:** Checking the initial URL is insufficient if the HTTP client automatically follows redirects. Attackers can use redirects to reach forbidden internal endpoints.
+**Prevention:** Always disable automatic redirects when fetching data from user-provided URLs (`new HttpClientHandler { AllowAutoRedirect = false }`) so the client does not inadvertently make requests to unvalidated destinations. Ensure that any redirects are explicitly handled and validated if necessary.

--- a/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Create.cshtml.cs
@@ -56,7 +56,8 @@ public class CreateModel : PageModel
                 return Page();
             }
 
-            using var httpClient = new HttpClient();
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)

--- a/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
+++ b/WhiskeyTracker.Web/Pages/Whiskies/Edit.cshtml.cs
@@ -70,7 +70,8 @@ public class EditModel : PageModel
                 return Page();
             }
 
-            using var httpClient = new HttpClient();
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using var httpClient = new HttpClient(handler);
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", GooglePhotoToken);
             var response = await httpClient.GetAsync(GooglePhotoUrl);
             if (response.IsSuccessStatusCode)

--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,0 +1,5 @@
+🚨 Severity: CRITICAL
+💡 Vulnerability: The application was susceptible to an SSRF bypass when fetching external URLs. While the initial URL was validated to only allow trusted Google domains, `HttpClient` automatically follows HTTP redirects by default. An attacker could use an open redirect to point the application toward unvalidated internal or external services.
+🎯 Impact: Attackers could potentially map internal network architecture, access unauthenticated internal APIs, or exfiltrate data by exploiting the auto-redirect behavior of the `HttpClient`.
+🔧 Fix: Updated the instantiation of `HttpClient` in both `Create.cshtml.cs` and `Edit.cshtml.cs` to use an `HttpClientHandler` with `AllowAutoRedirect = false`, preventing the application from automatically following redirects to unvalidated destinations.
+✅ Verification: Ensure the test suite continues to pass (`dotnet test`) and review the updated `.jules/sentinel.md` journal file.


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application was susceptible to an SSRF bypass when fetching external URLs. While the initial URL was validated to only allow trusted Google domains, `HttpClient` automatically follows HTTP redirects by default. An attacker could use an open redirect to point the application toward unvalidated internal or external services.
🎯 Impact: Attackers could potentially map internal network architecture, access unauthenticated internal APIs, or exfiltrate data by exploiting the auto-redirect behavior of the `HttpClient`.
🔧 Fix: Updated the instantiation of `HttpClient` in both `Create.cshtml.cs` and `Edit.cshtml.cs` to use an `HttpClientHandler` with `AllowAutoRedirect = false`, preventing the application from automatically following redirects to unvalidated destinations.
✅ Verification: Ensure the test suite continues to pass (`dotnet test`) and review the updated `.jules/sentinel.md` journal file.

---
*PR created automatically by Jules for task [16620197715800567513](https://jules.google.com/task/16620197715800567513) started by @whwar9739*